### PR TITLE
Generating type definitions for TypeScript

### DIFF
--- a/matssocket-client-javascript/client/package.json
+++ b/matssocket-client-javascript/client/package.json
@@ -24,11 +24,13 @@
   },
 
   "scripts": {
+    "prebuild": "tsc",
     "build": "rollup --config"
   },
 
   "devDependencies": {
     "rollup": "^2.52.7",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^4.8.4"
   }
 }

--- a/matssocket-client-javascript/client/tsconfig.json
+++ b/matssocket-client-javascript/client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "include": [
+    "lib/**/*"
+  ],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as normally they are ignored as source files.
+    "allowJs": true,
+    // Generate d.ts files.
+    "declaration": true,
+    // This compiler run should only output d.ts files.
+    "emitDeclarationOnly": true,
+    // Types should go into the output directory.
+    "outDir": "bundles",
+    // Go to js file when using IDE functions like "Go to Definition" in VSCode.
+    "declarationMap": true
+  }
+}

--- a/matssocket-client-javascript/client/yarn.lock
+++ b/matssocket-client-javascript/client/yarn.lock
@@ -182,6 +182,11 @@ terser@^5.0.0:
     source-map "~0.7.2"
     source-map-support "~0.5.19"
 
+typescript@^4.8.4:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+
 ws@^7.2.1:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.2.tgz#09cc8fea3bec1bc5ed44ef51b42f945be36900f6"


### PR DESCRIPTION
Added TypeScript as a dev dependency, and created a tsconfig.json which generates type definitions based on existing javascript code.

I contribute this material in accordance with Storebrand's signed SCA.