### PR TITLE
Add Quarkus adapter for MatsSocket server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ ext {
     jacksonVersion = '3.0.1'
     slf4jVersion = '2.0.17'
 
+    // Quarkus adapter
+    quarkusVersion = '3.16.3'
+
     // Optional for DB setup/migration
     flywayVersion = '11.15.0'
 
@@ -80,7 +83,7 @@ tasks.named("dependencyUpdates").configure {
 }
 
 // Common config for the two Java subprojects
-configure([project('matssocket-server-api'), project('matssocket-server-impl')]) {
+configure([project('matssocket-server-api'), project('matssocket-server-impl'), project('matssocket-server-quarkus')]) {
     apply plugin: 'java-library'
     apply plugin: "com.vanniktech.maven.publish"
 

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/PostgreSqlRewritingDataSource.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/PostgreSqlRewritingDataSource.java
@@ -1,0 +1,121 @@
+package io.mats3.matssocket.impl;
+
+import java.io.PrintWriter;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.sql.DataSource;
+
+/**
+ * DataSource wrapper that rewrites SQL Server "SELECT TOP n" syntax to PostgreSQL "LIMIT n".
+ * <p>
+ * This is needed because MatsSocket's ClusterStoreAndForward_SQL uses SQL Server syntax.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * DataSource dataSource = new PostgreSqlRewritingDataSource(actualDataSource);
+ * ClusterStoreAndForward_SQL csaf = ClusterStoreAndForward_SQL.create(dataSource, nodeName);
+ * }</pre>
+ */
+public class PostgreSqlRewritingDataSource implements DataSource {
+
+    private final DataSource delegate;
+
+    // Pattern to match "SELECT TOP n" and capture the number
+    private static final Pattern TOP_PATTERN = Pattern.compile(
+            "SELECT\\s+TOP\\s+(\\d+)\\s+", Pattern.CASE_INSENSITIVE);
+
+    public PostgreSqlRewritingDataSource(DataSource delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return wrapConnection(delegate.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return wrapConnection(delegate.getConnection(username, password));
+    }
+
+    /**
+     * Rewrite SQL Server TOP syntax to PostgreSQL LIMIT syntax.
+     * "SELECT TOP 20 col1, col2 FROM ..." becomes "SELECT col1, col2 FROM ... LIMIT 20"
+     */
+    static String rewriteSql(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        Matcher matcher = TOP_PATTERN.matcher(sql);
+        if (matcher.find()) {
+            String limit = matcher.group(1);
+            // Remove "TOP n" and append "LIMIT n" at the end
+            String rewritten = matcher.replaceFirst("SELECT ");
+            return rewritten + " LIMIT " + limit;
+        }
+        return sql;
+    }
+
+    private Connection wrapConnection(Connection connection) {
+        return (Connection) Proxy.newProxyInstance(
+                Connection.class.getClassLoader(),
+                new Class<?>[] { Connection.class },
+                (proxy, method, args) -> {
+                    Object[] actualArgs = args;
+                    if ((actualArgs != null) && (actualArgs.length > 0)
+                            && (actualArgs[0] instanceof String)
+                            && "prepareStatement".equals(method.getName())) {
+                        actualArgs = actualArgs.clone();
+                        actualArgs[0] = rewriteSql((String) actualArgs[0]);
+                    }
+                    try {
+                        return method.invoke(connection, actualArgs);
+                    }
+                    catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
+    }
+}

--- a/matssocket-server-impl/src/test/java/io/mats3/matssocket/impl/Test_PostgreSqlRewritingDataSource.java
+++ b/matssocket-server-impl/src/test/java/io/mats3/matssocket/impl/Test_PostgreSqlRewritingDataSource.java
@@ -1,0 +1,95 @@
+package io.mats3.matssocket.impl;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.sql.DataSource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Test_PostgreSqlRewritingDataSource {
+
+    @Test
+    public void rewriteSqlTransformsTopToLimit() {
+        String sql = "SELECT TOP 20 smid, trace_id FROM mats_socket_outbox WHERE session_id = ?";
+
+        String rewritten = PostgreSqlRewritingDataSource.rewriteSql(sql);
+
+        Assert.assertEquals(
+                "SELECT smid, trace_id FROM mats_socket_outbox WHERE session_id = ? LIMIT 20",
+                rewritten);
+    }
+
+    @Test
+    public void dataSourceWrapsPreparedStatementSql() throws Exception {
+        AtomicReference<String> preparedSql = new AtomicReference<>();
+
+        PreparedStatement preparedStatement = (PreparedStatement) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] { PreparedStatement.class },
+                (proxy, method, args) -> defaultValue(method.getReturnType()));
+
+        Connection connection = (Connection) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] { Connection.class },
+                (proxy, method, args) -> {
+                    if ("prepareStatement".equals(method.getName())) {
+                        preparedSql.set((String) args[0]);
+                        return preparedStatement;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        DataSource delegate = (DataSource) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] { DataSource.class },
+                (proxy, method, args) -> {
+                    if ("getConnection".equals(method.getName())) {
+                        return connection;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        DataSource dataSource = new PostgreSqlRewritingDataSource(delegate);
+        dataSource.getConnection().prepareStatement(
+                "SELECT TOP 5 smid, trace_id FROM mats_socket_outbox WHERE session_id = ?");
+
+        Assert.assertEquals(
+                "SELECT smid, trace_id FROM mats_socket_outbox WHERE session_id = ? LIMIT 5",
+                preparedSql.get());
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        if (returnType == double.class) {
+            return 0d;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        throw new IllegalArgumentException("Unknown primitive type: " + returnType);
+    }
+}

--- a/matssocket-server-quarkus/README.md
+++ b/matssocket-server-quarkus/README.md
@@ -1,0 +1,187 @@
+# MatsSocket Quarkus Adapter
+
+Adapter that bridges [Quarkus WebSockets Next](https://quarkus.io/guides/websockets-next-reference) to
+[MatsSocket](https://matssocket.io/), enabling MatsSocket to run on Quarkus without modification.
+
+## Overview
+
+MatsSocket is built on Jakarta WebSocket (JSR 356), which is the standard WebSocket API in Java EE / Jakarta EE.
+Quarkus WebSockets Next is a newer, reactive WebSocket implementation that is not directly compatible.
+
+This adapter implements the Jakarta WebSocket interfaces that MatsSocket requires, delegating to Quarkus
+WebSockets Next under the hood.
+
+## Installation
+
+```xml
+<dependency>
+    <groupId>io.mats3</groupId>
+    <artifactId>matssocket-server-quarkus</artifactId>
+    <version>2.0.0+2025-11-01</version>
+</dependency>
+```
+
+## Usage
+
+### 1. Create the MatsSocketServer
+
+```java
+@ApplicationScoped
+public class MatsSocketSetup {
+
+    @Inject MatsFactory matsFactory;
+    @Inject ClusterStoreAndForward csaf;
+
+    private MatsSocketQuarkusFactory.MatsSocketQuarkusSetup setup;
+
+    void onStart(@Observes StartupEvent event) {
+        setup = MatsSocketQuarkusFactory.create(
+            matsFactory, csaf, new MyAuthenticationPlugin(), "/matssocket");
+    }
+
+    @Produces @ApplicationScoped
+    public MatsSocketServer matsSocketServer() { return setup.server(); }
+
+    @Produces @ApplicationScoped
+    public QuarkusMatsSocketBridge matsSocketBridge() { return setup.bridge(); }
+}
+```
+
+### 2. Create the WebSocket Endpoint
+
+```java
+@WebSocket(path = "/matssocket")
+public class MatsSocketEndpoint {
+
+    @Inject QuarkusMatsSocketBridge bridge;
+
+    @OnOpen
+    void onOpen(WebSocketConnection conn, HandshakeRequest req) {
+        bridge.onOpen(conn, req);
+    }
+
+    @OnTextMessage
+    void onMessage(WebSocketConnection conn, String msg) {
+        bridge.onMessage(conn, msg);
+    }
+
+    @OnClose
+    void onClose(WebSocketConnection conn, CloseReason reason) {
+        bridge.onClose(conn, reason);
+    }
+
+    @OnError
+    void onError(WebSocketConnection conn, Throwable t) {
+        bridge.onError(conn, t);
+    }
+}
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Your Quarkus Application                      │
+├─────────────────────────────────────────────────────────────────┤
+│  @WebSocket Endpoint  ────────►  QuarkusMatsSocketBridge        │
+│         │                              │                         │
+│         ▼                              ▼                         │
+│  Quarkus WebSockets Next ◄────  QuarkusWebSocketSession         │
+│                                 (implements jakarta.websocket)   │
+├─────────────────────────────────────────────────────────────────┤
+│                       MatsSocket Server                          │
+│  (Official io.mats3.matssocket:matssocket-server-impl)          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Adapter Components
+
+| Component | Jakarta Interface | Purpose |
+|-----------|------------------|---------|
+| `QuarkusServerContainer` | `ServerContainer` | Captures endpoint registration |
+| `QuarkusWebSocketSession` | `Session` | Wraps Quarkus WebSocketConnection |
+| `QuarkusBasicRemote` | `RemoteEndpoint.Basic` | Synchronous message sending |
+| `QuarkusAsyncRemote` | `RemoteEndpoint.Async` | Async message sending |
+| `QuarkusHandshakeRequest` | `HandshakeRequest` | Access to headers/params |
+| `QuarkusHandshakeResponse` | `HandshakeResponse` | Handshake response (limited) |
+| `QuarkusMatsSocketBridge` | - | Routes events to MatsSocket |
+
+## MatsSocket API Compatibility
+
+### Full Support
+
+| Feature | Implementation |
+|---------|---------------|
+| `Session.getId()` | Maps to `WebSocketConnection.id()` |
+| `Session.getBasicRemote().sendText()` | Maps to `sendTextAndAwait()` |
+| `Session.getAsyncRemote().sendText()` | Maps to `sendText()` (reactive) |
+| `Session.addMessageHandler()` | Captures handler for routing |
+| `Session.getUserProperties()` | ConcurrentHashMap per session |
+| `Session.isOpen()` | Maps to `!connection.isClosed()` |
+| `Session.close()` | Maps to `connection.close()` |
+| `HandshakeRequest.getHeaders()` | ALL headers captured |
+| `HandshakeRequest.getParameterMap()` | Query string parsed |
+| `HandshakeRequest.getRequestURI()` | Constructed from Quarkus API |
+| `ServerEndpointConfig.Configurator` | Lifecycle support (see limitations below) |
+
+### Known Limitations
+
+| Feature | Limitation | Workaround |
+|---------|------------|------------|
+| `Session.setMaxIdleTimeout()` | No per-session timeout | Configure globally via `quarkus.websockets-next.server.idle-timeout` |
+| `Session.setMaxTextMessageBufferSize()` | No per-session buffer | Configure globally via `quarkus.websockets-next.server.max-message-size` |
+| Partial messages | Not supported | MatsSocket sends complete messages only |
+| `RemoteEndpoint.getSendStream()` | Not supported | MatsSocket doesn't use streaming |
+| Ping/Pong manual control | Automatic | Quarkus handles ping/pong automatically |
+| `getOpenSessions()` | Returns only self | Would need server-level tracking |
+| Remote address | Not exposed | Quarkus WebSockets Next doesn't expose client IP directly |
+| `HandshakeResponse` headers | Mutations not sent to client | Quarkus WebSockets Next does not support setting response headers during upgrade. Auth plugins that set `Set-Cookie` or similar on the handshake response will not take effect. |
+
+### Configuration
+
+Add to `application.properties`:
+
+```properties
+# WebSocket idle timeout (default: no timeout)
+quarkus.websockets-next.server.idle-timeout=PT5M
+
+# Max message size (default: 65536)
+quarkus.websockets-next.server.max-message-size=131072
+
+# Auto ping interval (default: disabled)
+quarkus.websockets-next.server.auto-ping-interval=PT30S
+```
+
+## Implementation Notes
+
+### Message Handler Capture
+
+MatsSocket registers its message handler via `Session.addMessageHandler()` during the `Endpoint.onOpen()`
+call. This adapter captures the handler and uses it in `QuarkusMatsSocketBridge.onMessage()`:
+
+```java
+// During onOpen, MatsSocket calls:
+session.addMessageHandler(new MatsSocketSessionAndMessageHandler(...));
+
+// The adapter captures this and routes incoming messages:
+sessionData.textHandler.onMessage(message);
+```
+
+### Authentication Flow
+
+The adapter supports MatsSocket's authentication flow with one caveat — response header mutations during handshake are not sent to the client (see Known Limitations):
+
+1. `Configurator.checkOrigin()` - Called with Origin header
+2. `Configurator.modifyHandshake()` - Called for authentication
+3. `Configurator.getEndpointInstance()` - Creates MatsSocket endpoint
+
+If authentication fails in `modifyHandshake()`, the connection is closed.
+
+## Contributing
+
+This adapter is designed to be self-contained with no application-specific dependencies.
+It could potentially be contributed upstream to the [MatsSocket project](https://github.com/centiservice/matssocket).
+
+## License
+
+Apache License 2.0 (same as MatsSocket)

--- a/matssocket-server-quarkus/build.gradle
+++ b/matssocket-server-quarkus/build.gradle
@@ -1,0 +1,51 @@
+// MatsSocket Quarkus Adapter
+// Bridges Quarkus WebSockets Next to Jakarta WebSocket interfaces,
+// enabling MatsSocket to run on Quarkus without modification.
+
+dependencies {
+    // MatsSocket Server API + Impl
+    api project(':matssocket-server-api')
+    implementation project(':matssocket-server-impl')
+
+    // Quarkus WebSockets Next - what we're adapting from
+    implementation platform("io.quarkus.platform:quarkus-bom:$quarkusVersion")
+    implementation 'io.quarkus:quarkus-websockets-next'
+    implementation 'io.quarkus:quarkus-arc'
+
+    // Jakarta WebSocket Client API - contains SendResult, SendHandler etc.
+    compileOnly "jakarta.websocket:jakarta.websocket-client-api:$jakartaWebsocketsVersion"
+
+    // SLF4J
+    compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+
+    // Jandex — generates the bean discovery index that Quarkus needs
+    implementation 'io.smallrye:jandex:3.2.0'
+
+    // :: TEST
+    testImplementation 'junit:junit:4.13.2'
+}
+
+def generatedJandexDir = layout.buildDirectory.dir('generated/jandex')
+
+// Generate META-INF/jandex.idx at compile time (equivalent to jandex-maven-plugin)
+tasks.register('jandex', JavaExec) {
+    dependsOn classes
+    classpath = configurations.compileClasspath
+    mainClass = 'org.jboss.jandex.Main'
+    def outputFile = generatedJandexDir.get().file('META-INF/jandex.idx').asFile
+    outputs.file(outputFile)
+    doFirst {
+        outputFile.parentFile.mkdirs()
+    }
+    args = ['-o', outputFile.absolutePath, sourceSets.main.output.classesDirs.singleFile.absolutePath]
+}
+jar.dependsOn jandex
+jar.from(generatedJandexDir)
+
+mavenPublishing {
+    pom {
+        name = 'MatsSocket Quarkus Adapter'
+        description = 'Adapter enabling MatsSocket server to run on Quarkus WebSockets Next.' +
+                ' Bridges Quarkus WebSockets to Jakarta WebSocket interfaces used by MatsSocket.'
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
@@ -1,0 +1,87 @@
+package io.mats3.matssocket.quarkus;
+
+import io.mats3.MatsFactory;
+import io.mats3.matssocket.AuthenticationPlugin;
+import io.mats3.matssocket.ClusterStoreAndForward;
+import io.mats3.matssocket.MatsSocketServer;
+import io.mats3.matssocket.impl.DefaultMatsSocketServer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates Quarkus-specific MatsSocket setups.
+ */
+public final class MatsSocketQuarkusFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(MatsSocketQuarkusFactory.class);
+
+    private MatsSocketQuarkusFactory() {
+    }
+
+    /**
+     * Create a MatsSocketServer configured for Quarkus.
+     *
+     * @param matsFactory The MATS factory for messaging
+     * @param clusterStoreAndForward Storage for reliable message delivery
+     * @param authenticationPlugin Plugin to authenticate WebSocket connections
+     * @param websocketPath The path where the WebSocket endpoint will be mounted (e.g., "/matssocket")
+     * @return Setup containing both the server and bridge
+     */
+    public static MatsSocketQuarkusSetup create(
+            MatsFactory matsFactory,
+            ClusterStoreAndForward clusterStoreAndForward,
+            AuthenticationPlugin authenticationPlugin,
+            String websocketPath) {
+
+        return create(matsFactory, clusterStoreAndForward, authenticationPlugin,
+            matsFactory.getFactoryConfig().getAppName(), websocketPath);
+    }
+
+    /**
+     * Create a MatsSocketServer configured for Quarkus with a specific instance name.
+     *
+     * @param matsFactory The MATS factory for messaging
+     * @param clusterStoreAndForward Storage for reliable message delivery
+     * @param authenticationPlugin Plugin to authenticate WebSocket connections
+     * @param instanceName Name for this MatsSocket instance
+     * @param websocketPath The path where the WebSocket endpoint will be mounted
+     * @return Setup containing both the server and bridge
+     */
+    public static MatsSocketQuarkusSetup create(
+            MatsFactory matsFactory,
+            ClusterStoreAndForward clusterStoreAndForward,
+            AuthenticationPlugin authenticationPlugin,
+            String instanceName,
+            String websocketPath) {
+
+        log.info("Creating MatsSocketServer for Quarkus at path: {}", websocketPath);
+
+        QuarkusServerContainer serverContainer = new QuarkusServerContainer();
+
+        MatsSocketServer matsSocketServer = DefaultMatsSocketServer.createMatsSocketServer(
+            serverContainer,
+            matsFactory,
+            clusterStoreAndForward,
+            authenticationPlugin,
+            instanceName,
+            websocketPath
+        );
+
+        QuarkusMatsSocketBridge bridge = new QuarkusMatsSocketBridge(serverContainer, websocketPath);
+
+        log.info("MatsSocketServer created successfully at path: {}", websocketPath);
+
+        return new MatsSocketQuarkusSetup(matsSocketServer, bridge, serverContainer, websocketPath);
+    }
+
+    /**
+     * Result of creating a MatsSocket setup for Quarkus.
+     */
+    public record MatsSocketQuarkusSetup(
+        MatsSocketServer server,
+        QuarkusMatsSocketBridge bridge,
+        QuarkusServerContainer serverContainer,
+        String websocketPath
+    ) {}
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusAsyncRemote.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusAsyncRemote.java
@@ -1,0 +1,111 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.SendHandler;
+import jakarta.websocket.SendResult;
+
+import io.quarkus.websockets.next.WebSocketConnection;
+
+public class QuarkusAsyncRemote implements RemoteEndpoint.Async {
+
+    private final WebSocketConnection connection;
+    private final jakarta.websocket.Session session;
+    private long sendTimeout = 0;
+    private boolean batchingAllowed = false;
+
+    public QuarkusAsyncRemote(WebSocketConnection connection, jakarta.websocket.Session session) {
+        this.connection = connection;
+        this.session = session;
+    }
+
+    @Override
+    public long getSendTimeout() {
+        return sendTimeout;
+    }
+
+    @Override
+    public void setSendTimeout(long timeoutmillis) {
+        this.sendTimeout = timeoutmillis;
+    }
+
+    @Override
+    public void sendText(String text, SendHandler handler) {
+        connection.sendText(text)
+            .subscribe()
+            .with(
+                v -> handler.onResult(new SendResult(session)),
+                e -> handler.onResult(new SendResult(session, e))
+            );
+    }
+
+    @Override
+    public Future<Void> sendText(String text) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        connection.sendText(text)
+            .subscribe()
+            .with(
+                v -> future.complete(null),
+                future::completeExceptionally
+            );
+        return future;
+    }
+
+    @Override
+    public void sendBinary(ByteBuffer data, SendHandler handler) {
+        connection.sendBinary(QuarkusBufferUtil.toVertxBuffer(data))
+            .subscribe()
+            .with(
+                v -> handler.onResult(new SendResult(session)),
+                e -> handler.onResult(new SendResult(session, e))
+            );
+    }
+
+    @Override
+    public Future<Void> sendBinary(ByteBuffer data) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        connection.sendBinary(QuarkusBufferUtil.toVertxBuffer(data))
+            .subscribe()
+            .with(
+                v -> future.complete(null),
+                future::completeExceptionally
+            );
+        return future;
+    }
+
+    @Override
+    public Future<Void> sendObject(Object data) {
+        throw new UnsupportedOperationException("sendObject not supported - MatsSocket handles serialization");
+    }
+
+    @Override
+    public void sendObject(Object data, SendHandler handler) {
+        throw new UnsupportedOperationException("sendObject not supported - MatsSocket handles serialization");
+    }
+
+    @Override
+    public void setBatchingAllowed(boolean allowed) throws IOException {
+        this.batchingAllowed = allowed;
+    }
+
+    @Override
+    public boolean getBatchingAllowed() {
+        return batchingAllowed;
+    }
+
+    @Override
+    public void flushBatch() throws IOException {
+    }
+
+    @Override
+    public void sendPing(ByteBuffer applicationData) throws IOException, IllegalArgumentException {
+    }
+
+    @Override
+    public void sendPong(ByteBuffer applicationData) throws IOException, IllegalArgumentException {
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusBasicRemote.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusBasicRemote.java
@@ -1,0 +1,94 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.ByteBuffer;
+
+import jakarta.websocket.EncodeException;
+import jakarta.websocket.RemoteEndpoint;
+
+import io.quarkus.websockets.next.WebSocketConnection;
+
+public class QuarkusBasicRemote implements RemoteEndpoint.Basic {
+
+    private final WebSocketConnection connection;
+    private boolean batchingAllowed = false;
+
+    public QuarkusBasicRemote(WebSocketConnection connection) {
+        this.connection = connection;
+    }
+
+    @Override
+    public void sendText(String text) throws IOException {
+        try {
+            connection.sendTextAndAwait(text);
+        } catch (Exception e) {
+            throw new IOException("Failed to send text message", e);
+        }
+    }
+
+    @Override
+    public void sendBinary(ByteBuffer data) throws IOException {
+        try {
+            connection.sendBinaryAndAwait(QuarkusBufferUtil.toVertxBuffer(data));
+        } catch (Exception e) {
+            throw new IOException("Failed to send binary message", e);
+        }
+    }
+
+    @Override
+    public void sendText(String partialMessage, boolean isLast) throws IOException {
+        if (isLast) {
+            sendText(partialMessage);
+        } else {
+            throw new UnsupportedOperationException("Partial text messages not supported in Quarkus adapter");
+        }
+    }
+
+    @Override
+    public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+        if (isLast) {
+            sendBinary(partialByte);
+        } else {
+            throw new UnsupportedOperationException("Partial binary messages not supported in Quarkus adapter");
+        }
+    }
+
+    @Override
+    public OutputStream getSendStream() throws IOException {
+        throw new UnsupportedOperationException("Streaming not supported in Quarkus adapter");
+    }
+
+    @Override
+    public Writer getSendWriter() throws IOException {
+        throw new UnsupportedOperationException("Streaming not supported in Quarkus adapter");
+    }
+
+    @Override
+    public void sendObject(Object data) throws IOException, EncodeException {
+        throw new UnsupportedOperationException("sendObject not supported - MatsSocket handles serialization");
+    }
+
+    @Override
+    public void setBatchingAllowed(boolean allowed) throws IOException {
+        this.batchingAllowed = allowed;
+    }
+
+    @Override
+    public boolean getBatchingAllowed() {
+        return batchingAllowed;
+    }
+
+    @Override
+    public void flushBatch() throws IOException {
+    }
+
+    @Override
+    public void sendPing(ByteBuffer applicationData) throws IOException, IllegalArgumentException {
+    }
+
+    @Override
+    public void sendPong(ByteBuffer applicationData) throws IOException, IllegalArgumentException {
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusBufferUtil.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusBufferUtil.java
@@ -1,0 +1,17 @@
+package io.mats3.matssocket.quarkus;
+
+import java.nio.ByteBuffer;
+
+import io.vertx.core.buffer.Buffer;
+
+final class QuarkusBufferUtil {
+    private QuarkusBufferUtil() {
+    }
+
+    static Buffer toVertxBuffer(ByteBuffer byteBuffer) {
+        ByteBuffer copy = byteBuffer.slice();
+        byte[] bytes = new byte[copy.remaining()];
+        copy.get(bytes);
+        return Buffer.buffer(bytes);
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
@@ -1,0 +1,134 @@
+package io.mats3.matssocket.quarkus;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.security.Principal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import jakarta.websocket.server.HandshakeRequest;
+
+/**
+ * Maps Quarkus handshake data to Jakarta's {@link HandshakeRequest}.
+ */
+public class QuarkusHandshakeRequest implements HandshakeRequest {
+
+    private final Map<String, List<String>> headers;
+    private final Map<String, List<String>> parameterMap;
+    private final URI requestUri;
+    private final String queryString;
+    private final Principal userPrincipal;
+
+    public QuarkusHandshakeRequest(io.quarkus.websockets.next.HandshakeRequest quarkusHandshake) {
+        this.headers = copyHeadersCaseInsensitive(quarkusHandshake != null ? quarkusHandshake.headers() : null);
+        this.parameterMap = new HashMap<>();
+        this.queryString = quarkusHandshake != null ? quarkusHandshake.query() : null;
+        if (queryString != null && !queryString.isEmpty()) {
+            parseQueryString(queryString, parameterMap);
+        }
+        if (quarkusHandshake != null) {
+            try {
+                String scheme = quarkusHandshake.scheme();
+                String host = quarkusHandshake.host();
+                int port = quarkusHandshake.port();
+                String path = quarkusHandshake.path();
+                String authority = host;
+                if ((scheme.equals("ws") || scheme.equals("http")) && port != 80 && port > 0) {
+                    authority = host + ":" + port;
+                } else if ((scheme.equals("wss") || scheme.equals("https")) && port != 443 && port > 0) {
+                    authority = host + ":" + port;
+                }
+
+                String fullPath = queryString != null && !queryString.isEmpty()
+                    ? path + "?" + queryString
+                    : path;
+                this.requestUri = new URI(scheme + "://" + authority + fullPath);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to construct request URI", e);
+            }
+        } else {
+            this.requestUri = null;
+        }
+        this.userPrincipal = null;
+    }
+
+    public QuarkusHandshakeRequest(Map<String, List<String>> headers,
+                                   Map<String, List<String>> parameterMap,
+                                   URI requestUri,
+                                   Principal userPrincipal) {
+        this.headers = copyHeadersCaseInsensitive(headers);
+        this.parameterMap = parameterMap != null ? new HashMap<>(parameterMap) : new HashMap<>();
+        this.requestUri = requestUri;
+        this.queryString = requestUri != null ? requestUri.getQuery() : null;
+        this.userPrincipal = userPrincipal;
+    }
+
+    private Map<String, List<String>> copyHeadersCaseInsensitive(Map<String, List<String>> sourceHeaders) {
+        Map<String, List<String>> copiedHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        if (sourceHeaders != null) {
+            sourceHeaders.forEach((name, values) -> copiedHeaders.put(name, List.copyOf(values)));
+        }
+        return copiedHeaders;
+    }
+
+    private void parseQueryString(String queryString, Map<String, List<String>> params) {
+        if (queryString == null || queryString.isEmpty()) {
+            return;
+        }
+        String[] pairs = queryString.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf('=');
+            String key = idx > 0 ? decode(pair.substring(0, idx)) : decode(pair);
+            String value = idx > 0 && pair.length() > idx + 1 ? decode(pair.substring(idx + 1)) : "";
+            params.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+        }
+    }
+
+    private String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return value;
+        }
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return userPrincipal;
+    }
+
+    @Override
+    public URI getRequestURI() {
+        return requestUri;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return false;
+    }
+
+    @Override
+    public Object getHttpSession() {
+        return null;
+    }
+
+    @Override
+    public Map<String, List<String>> getParameterMap() {
+        return Collections.unmodifiableMap(parameterMap);
+    }
+
+    @Override
+    public String getQueryString() {
+        return queryString;
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
@@ -1,0 +1,36 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.websocket.HandshakeResponse;
+
+/**
+ * Adapter for Jakarta WebSocket {@link HandshakeResponse}.
+ * <p>
+ * In Quarkus WebSockets Next, we can't actually modify the HTTP response headers after
+ * the upgrade. This implementation captures any headers that MatsSocket's authentication
+ * plugin might want to set, though they won't actually be sent.
+ * <p>
+ * For authentication, MatsSocket primarily uses the request headers (Authorization, cookies)
+ * rather than response headers, so this limitation is acceptable.
+ */
+public class QuarkusHandshakeResponse implements HandshakeResponse {
+
+    private final Map<String, List<String>> headers = new HashMap<>();
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Add a header to the response.
+     * Note: In Quarkus WebSockets Next, these headers may not actually be sent.
+     */
+    public void addHeader(String name, String value) {
+        headers.computeIfAbsent(name, k -> new ArrayList<>()).add(value);
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketBridge.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketBridge.java
@@ -1,0 +1,163 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.websockets.next.WebSocketConnection;
+
+/**
+ * Bridges Quarkus WebSocket callbacks to MatsSocket's Jakarta endpoint.
+ */
+public class QuarkusMatsSocketBridge {
+
+    private static final Logger log = LoggerFactory.getLogger(QuarkusMatsSocketBridge.class);
+
+    private final QuarkusServerContainer serverContainer;
+    private final String websocketPath;
+
+    private final Map<String, SessionData> activeSessions = new ConcurrentHashMap<>();
+
+    private static class SessionData {
+        final QuarkusWebSocketSession session;
+        final Endpoint endpoint;
+        MessageHandler.Whole<String> textHandler;
+
+        SessionData(QuarkusWebSocketSession session, Endpoint endpoint) {
+            this.session = session;
+            this.endpoint = endpoint;
+        }
+    }
+
+    public QuarkusMatsSocketBridge(QuarkusServerContainer serverContainer, String websocketPath) {
+        this.serverContainer = serverContainer;
+        this.websocketPath = websocketPath;
+    }
+
+    public void onOpen(WebSocketConnection connection, io.quarkus.websockets.next.HandshakeRequest handshakeRequest) {
+        log.debug("WebSocket connection opened: {}", connection.id());
+
+        ServerEndpointConfig config = serverContainer.getEndpointConfig(websocketPath);
+        if (config == null) {
+            log.error("No MatsSocket endpoint registered for path: {}", websocketPath);
+            closeConnection(connection);
+            return;
+        }
+
+        try {
+            ServerEndpointConfig.Configurator configurator = config.getConfigurator();
+            QuarkusHandshakeRequest jakartaHandshakeRequest = new QuarkusHandshakeRequest(handshakeRequest);
+            String origin = handshakeRequest.header("Origin");
+            if (origin != null && !configurator.checkOrigin(origin)) {
+                log.warn("Origin check failed for: {}", origin);
+                closeConnection(connection);
+                return;
+            }
+            QuarkusWebSocketSession jakartaSession = new QuarkusWebSocketSession(connection, jakartaHandshakeRequest);
+            QuarkusHandshakeResponse jakartaHandshakeResponse = new QuarkusHandshakeResponse();
+            try {
+                configurator.modifyHandshake(config, jakartaHandshakeRequest, jakartaHandshakeResponse);
+            } catch (Exception e) {
+                log.warn("Handshake rejected: {}", e.getMessage());
+                closeConnection(connection);
+                return;
+            }
+            @SuppressWarnings("unchecked")
+            Class<? extends Endpoint> endpointClass = (Class<? extends Endpoint>) config.getEndpointClass();
+            Endpoint endpoint = configurator.getEndpointInstance(endpointClass);
+            SessionData sessionData = new SessionData(jakartaSession, endpoint);
+            activeSessions.put(connection.id(), sessionData);
+            endpoint.onOpen(jakartaSession, config);
+            MessageHandler.Whole<String> registeredHandler = jakartaSession.getTextMessageHandler();
+            if (registeredHandler != null) {
+                sessionData.textHandler = registeredHandler;
+                log.info("MatsSocket connection established with handler: {}", connection.id());
+            } else {
+                log.warn("MatsSocket endpoint did not register a message handler for: {}", connection.id());
+            }
+
+        } catch (Exception e) {
+            log.error("Failed to initialize MatsSocket connection", e);
+            closeConnection(connection);
+        }
+    }
+
+    public void onMessage(WebSocketConnection connection, String message) {
+        SessionData sessionData = activeSessions.get(connection.id());
+        if (sessionData == null) {
+            log.warn("Received message for unknown connection: {}", connection.id());
+            return;
+        }
+
+        if (sessionData.textHandler != null) {
+            try {
+                sessionData.textHandler.onMessage(message);
+            } catch (Exception e) {
+                log.error("Error handling message", e);
+            }
+        } else {
+            log.warn("No message handler registered for connection: {}", connection.id());
+        }
+    }
+
+    public void onClose(WebSocketConnection connection) {
+        SessionData sessionData = activeSessions.remove(connection.id());
+        if (sessionData != null) {
+            try {
+                CloseReason closeReason = new CloseReason(
+                    CloseReason.CloseCodes.NORMAL_CLOSURE,
+                    "Connection closed"
+                );
+                sessionData.endpoint.onClose(sessionData.session, closeReason);
+                log.debug("MatsSocket connection closed: {}", connection.id());
+            } catch (Exception e) {
+                log.error("Error during close handling", e);
+            }
+        }
+    }
+
+    public void onClose(WebSocketConnection connection, io.quarkus.websockets.next.CloseReason reason) {
+        SessionData sessionData = activeSessions.remove(connection.id());
+        if (sessionData != null) {
+            try {
+                CloseReason.CloseCode closeCode = CloseReason.CloseCodes.getCloseCode(reason.getCode());
+                CloseReason closeReason = new CloseReason(closeCode, reason.getMessage());
+                sessionData.endpoint.onClose(sessionData.session, closeReason);
+                log.debug("MatsSocket connection closed: {} - {} {}",
+                    connection.id(), reason.getCode(), reason.getMessage());
+            } catch (Exception e) {
+                log.error("Error during close handling", e);
+            }
+        }
+    }
+
+    public void onError(WebSocketConnection connection, Throwable throwable) {
+        SessionData sessionData = activeSessions.get(connection.id());
+        if (sessionData != null) {
+            try {
+                sessionData.endpoint.onError(sessionData.session, throwable);
+            } catch (Exception e) {
+                log.error("Error during error handling", e);
+            }
+        }
+        log.error("WebSocket error for connection {}: {}", connection.id(), throwable.getMessage(), throwable);
+    }
+
+    public int getActiveConnectionCount() {
+        return activeSessions.size();
+    }
+
+    private void closeConnection(WebSocketConnection connection) {
+        connection.close().subscribe().with(
+            ignored -> {},
+            e -> log.warn("Error closing connection {}", connection.id(), e)
+        );
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerContainer.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerContainer.java
@@ -1,0 +1,124 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.websocket.ClientEndpointConfig;
+import jakarta.websocket.DeploymentException;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.Extension;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerContainer;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stores the endpoint config that MatsSocket registers for a Quarkus setup.
+ */
+public class QuarkusServerContainer implements ServerContainer {
+
+    private static final Logger log = LoggerFactory.getLogger(QuarkusServerContainer.class);
+
+    private final ConcurrentHashMap<String, ServerEndpointConfig> endpointConfigs = new ConcurrentHashMap<>();
+
+    private long defaultAsyncSendTimeout = 10000;
+    private long defaultMaxSessionIdleTimeout = 0;
+    private int defaultMaxBinaryMessageBufferSize = 65536;
+    private int defaultMaxTextMessageBufferSize = 65536;
+
+    @Override
+    public void addEndpoint(ServerEndpointConfig serverConfig) throws DeploymentException {
+        String path = serverConfig.getPath();
+        log.info("MatsSocket registering endpoint at path: {}", path);
+        endpointConfigs.put(path, serverConfig);
+    }
+
+    @Override
+    public void addEndpoint(Class<?> endpointClass) throws DeploymentException {
+        throw new UnsupportedOperationException(
+            "Annotation-based endpoints not supported in Quarkus adapter. Use addEndpoint(ServerEndpointConfig).");
+    }
+
+    public ServerEndpointConfig getEndpointConfig(String path) {
+        return endpointConfigs.get(path);
+    }
+
+    @Override
+    public void upgradeHttpToWebSocket(Object httpServletRequest, Object httpServletResponse,
+            ServerEndpointConfig sec, Map<String, String> pathParameters)
+            throws IOException, DeploymentException {
+        throw new UnsupportedOperationException(
+            "Programmatic HTTP upgrade not supported in Quarkus. Use @WebSocket annotations.");
+    }
+
+    @Override
+    public Session connectToServer(Object annotatedEndpointInstance, java.net.URI path) throws DeploymentException, IOException {
+        throw new UnsupportedOperationException("Client connections not supported in server adapter");
+    }
+
+    @Override
+    public Session connectToServer(Class<?> annotatedEndpointClass, java.net.URI path) throws DeploymentException, IOException {
+        throw new UnsupportedOperationException("Client connections not supported in server adapter");
+    }
+
+    @Override
+    public Session connectToServer(Endpoint endpointInstance, ClientEndpointConfig cec, java.net.URI path)
+            throws DeploymentException, IOException {
+        throw new UnsupportedOperationException("Client connections not supported in server adapter");
+    }
+
+    @Override
+    public Session connectToServer(Class<? extends Endpoint> endpointClass, ClientEndpointConfig cec, java.net.URI path)
+            throws DeploymentException, IOException {
+        throw new UnsupportedOperationException("Client connections not supported in server adapter");
+    }
+
+    @Override
+    public long getDefaultAsyncSendTimeout() {
+        return defaultAsyncSendTimeout;
+    }
+
+    @Override
+    public void setAsyncSendTimeout(long timeoutmillis) {
+        this.defaultAsyncSendTimeout = timeoutmillis;
+    }
+
+    @Override
+    public long getDefaultMaxSessionIdleTimeout() {
+        return defaultMaxSessionIdleTimeout;
+    }
+
+    @Override
+    public void setDefaultMaxSessionIdleTimeout(long timeout) {
+        this.defaultMaxSessionIdleTimeout = timeout;
+    }
+
+    @Override
+    public int getDefaultMaxBinaryMessageBufferSize() {
+        return defaultMaxBinaryMessageBufferSize;
+    }
+
+    @Override
+    public void setDefaultMaxBinaryMessageBufferSize(int max) {
+        this.defaultMaxBinaryMessageBufferSize = max;
+    }
+
+    @Override
+    public int getDefaultMaxTextMessageBufferSize() {
+        return defaultMaxTextMessageBufferSize;
+    }
+
+    @Override
+    public void setDefaultMaxTextMessageBufferSize(int max) {
+        this.defaultMaxTextMessageBufferSize = max;
+    }
+
+    @Override
+    public Set<Extension> getInstalledExtensions() {
+        return Set.of();
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusWebSocketSession.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusWebSocketSession.java
@@ -1,0 +1,203 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+import io.quarkus.websockets.next.WebSocketConnection;
+
+/**
+ * Maps a Quarkus {@link WebSocketConnection} to Jakarta's {@link Session}.
+ */
+public class QuarkusWebSocketSession implements Session {
+
+    private final WebSocketConnection quarkusConnection;
+    private final QuarkusHandshakeRequest handshakeRequest;
+    private final Map<String, Object> userProperties = new ConcurrentHashMap<>();
+
+    private long maxIdleTimeout = 0;
+    private int maxBinaryMessageBufferSize = 8192;
+    private int maxTextMessageBufferSize = 8192;
+
+    private volatile MessageHandler.Whole<String> textMessageHandler;
+
+    public QuarkusWebSocketSession(WebSocketConnection quarkusConnection, QuarkusHandshakeRequest handshakeRequest) {
+        this.quarkusConnection = quarkusConnection;
+        this.handshakeRequest = handshakeRequest;
+    }
+
+    @Override
+    public String getId() {
+        return quarkusConnection.id();
+    }
+
+    @Override
+    public WebSocketContainer getContainer() {
+        return null;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void addMessageHandler(MessageHandler handler) throws IllegalStateException {
+        if (handler instanceof MessageHandler.Whole) {
+            this.textMessageHandler = (MessageHandler.Whole<String>) handler;
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Whole<T> handler) {
+        if (clazz == String.class) {
+            this.textMessageHandler = (MessageHandler.Whole<String>) handler;
+        }
+    }
+
+    @Override
+    public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Partial<T> handler) {
+    }
+
+    @Override
+    public Set<MessageHandler> getMessageHandlers() {
+        return textMessageHandler != null ? Set.of(textMessageHandler) : Set.of();
+    }
+
+    @Override
+    public void removeMessageHandler(MessageHandler handler) {
+        if (handler == textMessageHandler) {
+            textMessageHandler = null;
+        }
+    }
+
+    public MessageHandler.Whole<String> getTextMessageHandler() {
+        return textMessageHandler;
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return "13";
+    }
+
+    @Override
+    public String getNegotiatedSubprotocol() {
+        return quarkusConnection.subprotocol() != null ? quarkusConnection.subprotocol() : "";
+    }
+
+    @Override
+    public List<Extension> getNegotiatedExtensions() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isSecure() {
+        return handshakeRequest != null &&
+               handshakeRequest.getRequestURI() != null &&
+               "wss".equalsIgnoreCase(handshakeRequest.getRequestURI().getScheme());
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !quarkusConnection.isClosed();
+    }
+
+    @Override
+    public long getMaxIdleTimeout() {
+        return maxIdleTimeout;
+    }
+
+    @Override
+    public void setMaxIdleTimeout(long milliseconds) {
+        this.maxIdleTimeout = milliseconds;
+    }
+
+    @Override
+    public void setMaxBinaryMessageBufferSize(int length) {
+        this.maxBinaryMessageBufferSize = length;
+    }
+
+    @Override
+    public int getMaxBinaryMessageBufferSize() {
+        return maxBinaryMessageBufferSize;
+    }
+
+    @Override
+    public void setMaxTextMessageBufferSize(int length) {
+        this.maxTextMessageBufferSize = length;
+    }
+
+    @Override
+    public int getMaxTextMessageBufferSize() {
+        return maxTextMessageBufferSize;
+    }
+
+    @Override
+    public RemoteEndpoint.Async getAsyncRemote() {
+        return new QuarkusAsyncRemote(quarkusConnection, this);
+    }
+
+    @Override
+    public RemoteEndpoint.Basic getBasicRemote() {
+        return new QuarkusBasicRemote(quarkusConnection);
+    }
+
+    @Override
+    public URI getRequestURI() {
+        return handshakeRequest != null ? handshakeRequest.getRequestURI() : null;
+    }
+
+    @Override
+    public Map<String, List<String>> getRequestParameterMap() {
+        return handshakeRequest != null ? handshakeRequest.getParameterMap() : Map.of();
+    }
+
+    @Override
+    public String getQueryString() {
+        URI uri = getRequestURI();
+        return uri != null ? uri.getQuery() : null;
+    }
+
+    @Override
+    public Map<String, String> getPathParameters() {
+        return Map.of();
+    }
+
+    @Override
+    public Map<String, Object> getUserProperties() {
+        return userProperties;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null;
+    }
+
+    @Override
+    public Set<Session> getOpenSessions() {
+        return Set.of(this);
+    }
+
+    @Override
+    public void close() throws IOException {
+        quarkusConnection.close().await().indefinitely();
+    }
+
+    @Override
+    public void close(CloseReason closeReason) throws IOException {
+        quarkusConnection.close(
+            new io.quarkus.websockets.next.CloseReason(
+                closeReason.getCloseCode().getCode(),
+                closeReason.getReasonPhrase()
+            )
+        ).await().indefinitely();
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/QuarkusTestSupport.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/QuarkusTestSupport.java
@@ -1,0 +1,335 @@
+package io.mats3.matssocket.quarkus;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import io.quarkus.websockets.next.HandshakeRequest;
+import io.quarkus.websockets.next.UserData;
+import io.quarkus.websockets.next.WebSocketConnection;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.buffer.Buffer;
+
+final class QuarkusTestSupport {
+    private QuarkusTestSupport() {
+    }
+
+    static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0f;
+        }
+        if (returnType == double.class) {
+            return 0d;
+        }
+        if (returnType == char.class) {
+            return '\0';
+        }
+        throw new IllegalArgumentException("Unknown primitive type: " + returnType);
+    }
+
+    static final class SimpleHandshakeRequest implements HandshakeRequest {
+        private final Map<String, List<String>> headers;
+        private final String scheme;
+        private final String host;
+        private final int port;
+        private final String path;
+        private final String query;
+
+        SimpleHandshakeRequest(Map<String, List<String>> headers, String scheme, String host, int port, String path,
+                String query) {
+            this.headers = new HashMap<>(headers);
+            this.scheme = scheme;
+            this.host = host;
+            this.port = port;
+            this.path = path;
+            this.query = query;
+        }
+
+        @Override
+        public String header(String name) {
+            List<String> values = headers(name);
+            return values.isEmpty() ? null : values.get(0);
+        }
+
+        @Override
+        public List<String> headers(String name) {
+            for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                if (entry.getKey().equalsIgnoreCase(name)) {
+                    return entry.getValue();
+                }
+            }
+            return List.of();
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return headers;
+        }
+
+        @Override
+        public String scheme() {
+            return scheme;
+        }
+
+        @Override
+        public String host() {
+            return host;
+        }
+
+        @Override
+        public int port() {
+            return port;
+        }
+
+        @Override
+        public String path() {
+            return path;
+        }
+
+        @Override
+        public String query() {
+            return query;
+        }
+    }
+
+    static final class RecordingWebSocketConnection implements WebSocketConnection {
+        private final String id;
+        private final HandshakeRequest handshakeRequest;
+
+        private boolean closed;
+        private Throwable nextSendFailure;
+        private Throwable nextCloseFailure;
+        private String lastText;
+        private Buffer lastBinary;
+        private int closeCalls;
+        private io.quarkus.websockets.next.CloseReason closeReason;
+
+        RecordingWebSocketConnection(String id, HandshakeRequest handshakeRequest) {
+            this.id = id;
+            this.handshakeRequest = handshakeRequest;
+        }
+
+        void failNextSend(Throwable throwable) {
+            nextSendFailure = throwable;
+        }
+
+        void failNextClose(Throwable throwable) {
+            nextCloseFailure = throwable;
+        }
+
+        String getLastText() {
+            return lastText;
+        }
+
+        Buffer getLastBinary() {
+            return lastBinary;
+        }
+
+        int getCloseCalls() {
+            return closeCalls;
+        }
+
+        @Override
+        public String endpointId() {
+            return "endpoint";
+        }
+
+        @Override
+        public BroadcastSender broadcast() {
+            return null;
+        }
+
+        @Override
+        public Set<WebSocketConnection> getOpenConnections() {
+            return Set.of(this);
+        }
+
+        @Override
+        public String subprotocol() {
+            return "matssocket";
+        }
+
+        @Override
+        public String id() {
+            return id;
+        }
+
+        @Override
+        public String pathParam(String name) {
+            return null;
+        }
+
+        @Override
+        public boolean isSecure() {
+            return false;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return closed;
+        }
+
+        @Override
+        public io.quarkus.websockets.next.CloseReason closeReason() {
+            return closeReason;
+        }
+
+        @Override
+        public Uni<Void> close(io.quarkus.websockets.next.CloseReason reason) {
+            closeCalls++;
+            closeReason = reason;
+            closed = true;
+            if (nextCloseFailure != null) {
+                Throwable throwable = nextCloseFailure;
+                nextCloseFailure = null;
+                return Uni.createFrom().failure(throwable);
+            }
+            return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public HandshakeRequest handshakeRequest() {
+            return handshakeRequest;
+        }
+
+        @Override
+        public Instant creationTime() {
+            return Instant.now();
+        }
+
+        @Override
+        public UserData userData() {
+            return null;
+        }
+
+        @Override
+        public Uni<Void> sendText(String message) {
+            if (nextSendFailure != null) {
+                Throwable throwable = nextSendFailure;
+                nextSendFailure = null;
+                return Uni.createFrom().failure(throwable);
+            }
+            lastText = message;
+            return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public <M> Uni<Void> sendText(M message) {
+            return sendText(String.valueOf(message));
+        }
+
+        @Override
+        public Uni<Void> sendBinary(Buffer message) {
+            if (nextSendFailure != null) {
+                Throwable throwable = nextSendFailure;
+                nextSendFailure = null;
+                return Uni.createFrom().failure(throwable);
+            }
+            lastBinary = message;
+            return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public Uni<Void> sendPing(Buffer message) {
+            return Uni.createFrom().voidItem();
+        }
+
+        @Override
+        public Uni<Void> sendPong(Buffer message) {
+            return Uni.createFrom().voidItem();
+        }
+    }
+
+    static class RecordingEndpoint extends Endpoint {
+        jakarta.websocket.Session openedSession;
+        EndpointConfig openedConfig;
+        final List<String> messages = new ArrayList<>();
+        jakarta.websocket.CloseReason closedReason;
+        Throwable error;
+
+        @Override
+        public void onOpen(jakarta.websocket.Session session, EndpointConfig config) {
+            openedSession = session;
+            openedConfig = config;
+            session.addMessageHandler(new MessageHandler.Whole<String>() {
+                @Override
+                public void onMessage(String message) {
+                    messages.add(message);
+                }
+            });
+        }
+
+        @Override
+        public void onClose(jakarta.websocket.Session session, jakarta.websocket.CloseReason closeReason) {
+            closedReason = closeReason;
+        }
+
+        @Override
+        public void onError(jakarta.websocket.Session session, Throwable thr) {
+            error = thr;
+        }
+    }
+
+    static final class RecordingConfigurator extends ServerEndpointConfig.Configurator {
+        private final Endpoint endpoint;
+        private final boolean originAllowed;
+        private final RuntimeException handshakeFailure;
+        private int modifyHandshakeCalls;
+
+        RecordingConfigurator(Endpoint endpoint, boolean originAllowed, RuntimeException handshakeFailure) {
+            this.endpoint = endpoint;
+            this.originAllowed = originAllowed;
+            this.handshakeFailure = handshakeFailure;
+        }
+
+        int getModifyHandshakeCalls() {
+            return modifyHandshakeCalls;
+        }
+
+        @Override
+        public boolean checkOrigin(String originHeaderValue) {
+            return originAllowed;
+        }
+
+        @Override
+        public void modifyHandshake(ServerEndpointConfig sec, jakarta.websocket.server.HandshakeRequest request,
+                jakarta.websocket.HandshakeResponse response) {
+            modifyHandshakeCalls++;
+            if (handshakeFailure != null) {
+                throw handshakeFailure;
+            }
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T getEndpointInstance(Class<T> endpointClass) {
+            return (T) endpoint;
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_MatsSocketQuarkusFactory.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_MatsSocketQuarkusFactory.java
@@ -1,0 +1,287 @@
+package io.mats3.matssocket.quarkus;
+
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.mats3.MatsEndpoint;
+import io.mats3.MatsFactory;
+import io.mats3.MatsStage;
+import io.mats3.matssocket.AuthenticationPlugin;
+import io.mats3.matssocket.ClusterStoreAndForward;
+
+public class Test_MatsSocketQuarkusFactory {
+
+    @Test
+    public void createReturnsIndependentSetupsForEachWebSocketPath() {
+        MatsFactory matsFactory = createMatsFactory("test-app", "test-node");
+        ClusterStoreAndForward clusterStoreAndForward = createClusterStoreAndForward();
+        AuthenticationPlugin authenticationPlugin = createAuthenticationPlugin();
+
+        MatsSocketQuarkusFactory.MatsSocketQuarkusSetup first = MatsSocketQuarkusFactory.create(
+                matsFactory,
+                clusterStoreAndForward,
+                authenticationPlugin,
+                "instance-one",
+                "/socket-one");
+        MatsSocketQuarkusFactory.MatsSocketQuarkusSetup second = MatsSocketQuarkusFactory.create(
+                matsFactory,
+                clusterStoreAndForward,
+                authenticationPlugin,
+                "instance-two",
+                "/socket-two");
+
+        try {
+            Assert.assertNotSame(first.serverContainer(), second.serverContainer());
+            Assert.assertNotSame(first.bridge(), second.bridge());
+            Assert.assertNotSame(first.server(), second.server());
+            Assert.assertEquals("/socket-one", first.websocketPath());
+            Assert.assertEquals("/socket-two", second.websocketPath());
+            Assert.assertNotNull(first.serverContainer().getEndpointConfig("/socket-one"));
+            Assert.assertNull(first.serverContainer().getEndpointConfig("/socket-two"));
+            Assert.assertNull(second.serverContainer().getEndpointConfig("/socket-one"));
+            Assert.assertNotNull(second.serverContainer().getEndpointConfig("/socket-two"));
+        } finally {
+            first.server().stop(0);
+            second.server().stop(0);
+        }
+    }
+
+    private static MatsFactory createMatsFactory(String appName, String nodeName) {
+        MatsFactory.FactoryConfig factoryConfig = (MatsFactory.FactoryConfig) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { MatsFactory.FactoryConfig.class },
+                new ConfigInvocationHandler(appName, nodeName));
+
+        return (MatsFactory) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { MatsFactory.class },
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getFactoryConfig":
+                            return factoryConfig;
+                        case "terminator":
+                        case "subscriptionTerminator":
+                        case "single":
+                            applyConfigConsumers(args);
+                            return createEndpointProxy();
+                        case "getEndpoints":
+                            return List.of();
+                        case "getEndpoint":
+                            return Optional.empty();
+                        case "stop":
+                        case "waitForReceiving":
+                            return true;
+                        case "start":
+                        case "holdEndpointsUntilFactoryIsStarted":
+                        case "close":
+                            return null;
+                        default:
+                            return QuarkusTestSupport.defaultValue(method.getReturnType());
+                    }
+                });
+    }
+
+    private static void applyConfigConsumers(Object[] args) {
+        if (args == null) {
+            return;
+        }
+        if (args.length >= 4 && args[3] instanceof Consumer<?> endpointConfigConsumer) {
+            @SuppressWarnings("unchecked")
+            Consumer<MatsEndpoint.EndpointConfig<?, ?>> consumer =
+                    (Consumer<MatsEndpoint.EndpointConfig<?, ?>>) endpointConfigConsumer;
+            consumer.accept(createEndpointConfigProxy());
+        }
+        if (args.length >= 5 && args[4] instanceof Consumer<?> stageConfigConsumer) {
+            @SuppressWarnings("unchecked")
+            Consumer<MatsStage.StageConfig<?, ?, ?>> consumer =
+                    (Consumer<MatsStage.StageConfig<?, ?, ?>>) stageConfigConsumer;
+            consumer.accept(createStageConfigProxy());
+        }
+    }
+
+    private static MatsEndpoint<?, ?> createEndpointProxy() {
+        return (MatsEndpoint<?, ?>) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { MatsEndpoint.class },
+                (proxy, method, args) -> QuarkusTestSupport.defaultValue(method.getReturnType()));
+    }
+
+    private static MatsEndpoint.EndpointConfig<?, ?> createEndpointConfigProxy() {
+        return (MatsEndpoint.EndpointConfig<?, ?>) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { MatsEndpoint.EndpointConfig.class },
+                new SimpleConfigInvocationHandler());
+    }
+
+    private static MatsStage.StageConfig<?, ?, ?> createStageConfigProxy() {
+        return (MatsStage.StageConfig<?, ?, ?>) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { MatsStage.StageConfig.class },
+                new SimpleConfigInvocationHandler());
+    }
+
+    private static ClusterStoreAndForward createClusterStoreAndForward() {
+        return (ClusterStoreAndForward) Proxy.newProxyInstance(
+                Test_MatsSocketQuarkusFactory.class.getClassLoader(),
+                new Class<?>[] { ClusterStoreAndForward.class },
+                (proxy, method, args) -> {
+                    if ("boot".equals(method.getName())) {
+                        return null;
+                    }
+                    if (method.getReturnType() == Optional.class) {
+                        return Optional.empty();
+                    }
+                    if (method.getReturnType() == List.class) {
+                        return List.of();
+                    }
+                    return QuarkusTestSupport.defaultValue(method.getReturnType());
+                });
+    }
+
+    private static AuthenticationPlugin createAuthenticationPlugin() {
+        return () -> new AuthenticationPlugin.SessionAuthenticator() {
+            @Override
+            public AuthenticationPlugin.AuthenticationResult initialAuthentication(
+                    AuthenticationPlugin.AuthenticationContext context, String authorizationHeader) {
+                return null;
+            }
+
+            @Override
+            public AuthenticationPlugin.AuthenticationResult reevaluateAuthentication(
+                    AuthenticationPlugin.AuthenticationContext context,
+                    String authorizationHeader, java.security.Principal existingPrincipal) {
+                return null;
+            }
+        };
+    }
+
+    private static class ConfigInvocationHandler implements java.lang.reflect.InvocationHandler {
+        private final String appName;
+        private final String nodeName;
+        private final AtomicInteger concurrency = new AtomicInteger(2);
+        private final AtomicInteger interactiveConcurrency = new AtomicInteger(2);
+        private final Map<String, Object> attributes = new HashMap<>();
+
+        ConfigInvocationHandler(String appName, String nodeName) {
+            this.appName = appName;
+            this.nodeName = nodeName;
+        }
+
+        @Override
+        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+            switch (method.getName()) {
+                case "getAppName":
+                case "getName":
+                    return appName;
+                case "getNodename":
+                    return nodeName;
+                case "getConcurrency":
+                    return concurrency.get();
+                case "setConcurrency":
+                    concurrency.set((Integer) args[0]);
+                    return proxy;
+                case "isConcurrencyDefault":
+                    return false;
+                case "getInteractiveConcurrency":
+                    return interactiveConcurrency.get();
+                case "setInteractiveConcurrency":
+                    interactiveConcurrency.set((Integer) args[0]);
+                    return proxy;
+                case "isInteractiveConcurrencyDefault":
+                    return false;
+                case "isRunning":
+                    return true;
+                case "setAttribute":
+                    attributes.put((String) args[0], args[1]);
+                    return proxy;
+                case "getAttribute":
+                    return attributes.get(args[0]);
+                case "setName":
+                case "setNodename":
+                case "setCommonEndpointGroupId":
+                case "setInitiateTraceIdModifier":
+                case "setMatsDestinationPrefix":
+                case "setMatsTraceKey":
+                case "installPlugin":
+                    return proxy;
+                case "getCommonEndpointGroupId":
+                case "getMatsDestinationPrefix":
+                case "getMatsTraceKey":
+                case "getAppVersion":
+                case "getSystemInformation":
+                case "getMatsImplementationName":
+                case "getMatsImplementationVersion":
+                    return "";
+                case "getPlugins":
+                    return List.of();
+                case "removePlugin":
+                    return false;
+                case "instantiateNewObject":
+                    return null;
+                case "getNumberOfCpus":
+                    return 1;
+                default:
+                    return QuarkusTestSupport.defaultValue(method.getReturnType());
+            }
+        }
+    }
+
+    private static class SimpleConfigInvocationHandler implements java.lang.reflect.InvocationHandler {
+        private final AtomicInteger concurrency = new AtomicInteger(1);
+        private final AtomicInteger interactiveConcurrency = new AtomicInteger(1);
+        private final Map<String, Object> attributes = new HashMap<>();
+
+        @Override
+        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+            switch (method.getName()) {
+                case "getConcurrency":
+                    return concurrency.get();
+                case "setConcurrency":
+                    concurrency.set((Integer) args[0]);
+                    return proxy;
+                case "isConcurrencyDefault":
+                    return false;
+                case "getInteractiveConcurrency":
+                    return interactiveConcurrency.get();
+                case "setInteractiveConcurrency":
+                    interactiveConcurrency.set((Integer) args[0]);
+                    return proxy;
+                case "isInteractiveConcurrencyDefault":
+                    return false;
+                case "isRunning":
+                    return true;
+                case "setAttribute":
+                    attributes.put((String) args[0], args[1]);
+                    return proxy;
+                case "getAttribute":
+                    return attributes.get(args[0]);
+                case "getOrigin":
+                case "getEndpointId":
+                case "getStageId":
+                    return "";
+                case "getStageIndex":
+                case "getRunningStageProcessors":
+                    return 0;
+                case "getReplyClass":
+                case "getStateClass":
+                case "getIncomingClass":
+                case "getProcessLambda":
+                    return null;
+                case "isSubscription":
+                    return false;
+                case "setOrigin":
+                    return proxy;
+                default:
+                    return QuarkusTestSupport.defaultValue(method.getReturnType());
+            }
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
@@ -1,0 +1,35 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Test_QuarkusHandshakeRequest {
+
+    @Test
+    public void quarkusHandshakeIsMappedToCaseInsensitiveJakartaRequest() {
+        QuarkusTestSupport.SimpleHandshakeRequest handshake = new QuarkusTestSupport.SimpleHandshakeRequest(
+                Map.of(
+                        "cookie", List.of("auth=abc"),
+                        "x-test", List.of("one", "two")),
+                "wss",
+                "example.test",
+                8443,
+                "/socket",
+                "foo=bar&foo=baz&encoded=hello+world&empty&equals=a%3Db");
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(handshake);
+
+        Assert.assertEquals(List.of("auth=abc"), request.getHeaders().get("Cookie"));
+        Assert.assertEquals(List.of("one", "two"), request.getHeaders().get("X-Test"));
+        Assert.assertEquals(List.of("bar", "baz"), request.getParameterMap().get("foo"));
+        Assert.assertEquals(List.of("hello world"), request.getParameterMap().get("encoded"));
+        Assert.assertEquals(List.of(""), request.getParameterMap().get("empty"));
+        Assert.assertEquals(List.of("a=b"), request.getParameterMap().get("equals"));
+        Assert.assertEquals("foo=bar&foo=baz&encoded=hello+world&empty&equals=a%3Db", request.getQueryString());
+        Assert.assertEquals("wss://example.test:8443/socket?foo=bar&foo=baz&encoded=hello+world&empty&equals=a%3Db",
+                request.getRequestURI().toString());
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusMatsSocketBridge.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusMatsSocketBridge.java
@@ -1,0 +1,111 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.websocket.server.ServerEndpointConfig;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Test_QuarkusMatsSocketBridge {
+
+    @Test
+    public void bridgeForwardsOpenMessageCloseAndError() throws Exception {
+        QuarkusServerContainer serverContainer = new QuarkusServerContainer();
+        QuarkusTestSupport.RecordingEndpoint endpoint = new QuarkusTestSupport.RecordingEndpoint();
+        QuarkusTestSupport.RecordingConfigurator configurator = new QuarkusTestSupport.RecordingConfigurator(
+                endpoint, true, null);
+        ServerEndpointConfig config = ServerEndpointConfig.Builder
+                .create(QuarkusTestSupport.RecordingEndpoint.class, "/socket")
+                .configurator(configurator)
+                .build();
+        serverContainer.addEndpoint(config);
+
+        QuarkusMatsSocketBridge bridge = new QuarkusMatsSocketBridge(serverContainer, "/socket");
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-1",
+                new QuarkusTestSupport.SimpleHandshakeRequest(
+                        Map.of("Origin", List.of("https://client.test")),
+                        "wss",
+                        "example.test",
+                        443,
+                        "/socket",
+                        "client=1"));
+
+        bridge.onOpen(connection, connection.handshakeRequest());
+        bridge.onMessage(connection, "payload");
+        RuntimeException error = new RuntimeException("boom");
+        bridge.onError(connection, error);
+        bridge.onClose(connection, new io.quarkus.websockets.next.CloseReason(1001, "going away"));
+
+        Assert.assertNotNull(endpoint.openedSession);
+        Assert.assertSame(config, endpoint.openedConfig);
+        Assert.assertEquals(List.of("payload"), endpoint.messages);
+        Assert.assertSame(error, endpoint.error);
+        Assert.assertEquals(1001, endpoint.closedReason.getCloseCode().getCode());
+        Assert.assertEquals("going away", endpoint.closedReason.getReasonPhrase());
+        Assert.assertEquals(0, bridge.getActiveConnectionCount());
+        Assert.assertEquals(1, configurator.getModifyHandshakeCalls());
+    }
+
+    @Test
+    public void bridgeRejectsOriginBeforeOpeningSession() throws Exception {
+        QuarkusServerContainer serverContainer = new QuarkusServerContainer();
+        QuarkusTestSupport.RecordingEndpoint endpoint = new QuarkusTestSupport.RecordingEndpoint();
+        QuarkusTestSupport.RecordingConfigurator configurator = new QuarkusTestSupport.RecordingConfigurator(
+                endpoint, false, null);
+        serverContainer.addEndpoint(ServerEndpointConfig.Builder
+                .create(QuarkusTestSupport.RecordingEndpoint.class, "/socket")
+                .configurator(configurator)
+                .build());
+
+        QuarkusMatsSocketBridge bridge = new QuarkusMatsSocketBridge(serverContainer, "/socket");
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-origin",
+                new QuarkusTestSupport.SimpleHandshakeRequest(
+                        Map.of("Origin", List.of("https://blocked.test")),
+                        "ws",
+                        "localhost",
+                        80,
+                        "/socket",
+                        null));
+
+        bridge.onOpen(connection, connection.handshakeRequest());
+
+        Assert.assertNull(endpoint.openedSession);
+        Assert.assertEquals(1, connection.getCloseCalls());
+        Assert.assertEquals(0, bridge.getActiveConnectionCount());
+        Assert.assertEquals(0, configurator.getModifyHandshakeCalls());
+    }
+
+    @Test
+    public void bridgeClosesConnectionWhenHandshakeFails() throws Exception {
+        QuarkusServerContainer serverContainer = new QuarkusServerContainer();
+        QuarkusTestSupport.RecordingEndpoint endpoint = new QuarkusTestSupport.RecordingEndpoint();
+        QuarkusTestSupport.RecordingConfigurator configurator = new QuarkusTestSupport.RecordingConfigurator(
+                endpoint, true, new IllegalStateException("nope"));
+        serverContainer.addEndpoint(ServerEndpointConfig.Builder
+                .create(QuarkusTestSupport.RecordingEndpoint.class, "/socket")
+                .configurator(configurator)
+                .build());
+
+        QuarkusMatsSocketBridge bridge = new QuarkusMatsSocketBridge(serverContainer, "/socket");
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-handshake",
+                new QuarkusTestSupport.SimpleHandshakeRequest(
+                        Map.of("Origin", List.of("https://client.test")),
+                        "ws",
+                        "localhost",
+                        80,
+                        "/socket",
+                        null));
+
+        bridge.onOpen(connection, connection.handshakeRequest());
+
+        Assert.assertNull(endpoint.openedSession);
+        Assert.assertEquals(1, connection.getCloseCalls());
+        Assert.assertEquals(1, configurator.getModifyHandshakeCalls());
+        Assert.assertEquals(0, bridge.getActiveConnectionCount());
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusRemotes.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusRemotes.java
@@ -1,0 +1,90 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.websocket.SendResult;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.vertx.core.buffer.Buffer;
+
+public class Test_QuarkusRemotes {
+
+    @Test
+    public void bufferUtilCopiesRemainingBytesFromDirectBuffer() {
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(6);
+        byteBuffer.put(new byte[] { 1, 2, 3, 4, 5, 6 });
+        byteBuffer.position(1);
+        byteBuffer.limit(4);
+
+        Buffer buffer = QuarkusBufferUtil.toVertxBuffer(byteBuffer);
+
+        Assert.assertArrayEquals(new byte[] { 2, 3, 4 }, buffer.getBytes());
+        Assert.assertEquals(1, byteBuffer.position());
+        Assert.assertEquals(4, byteBuffer.limit());
+    }
+
+    @Test
+    public void basicRemoteSendsOnlyRemainingBinaryBytes() throws IOException {
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-basic",
+                new QuarkusTestSupport.SimpleHandshakeRequest(Map.of(), "ws", "localhost", 80, "/ws", null));
+        ByteBuffer byteBuffer = ByteBuffer.allocateDirect(5);
+        byteBuffer.put(new byte[] { 10, 11, 12, 13, 14 });
+        byteBuffer.position(2);
+        byteBuffer.limit(4);
+
+        new QuarkusBasicRemote(connection).sendBinary(byteBuffer);
+
+        Assert.assertArrayEquals(new byte[] { 12, 13 }, connection.getLastBinary().getBytes());
+    }
+
+    @Test
+    public void asyncRemoteCompletesHandlerAndFuture() throws Exception {
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-async",
+                new QuarkusTestSupport.SimpleHandshakeRequest(Map.of(), "ws", "localhost", 80, "/ws", null));
+        QuarkusWebSocketSession session = new QuarkusWebSocketSession(connection, null);
+        QuarkusAsyncRemote asyncRemote = new QuarkusAsyncRemote(connection, session);
+        AtomicReference<SendResult> sendResult = new AtomicReference<>();
+
+        asyncRemote.sendText("hello", sendResult::set);
+        asyncRemote.sendBinary(ByteBuffer.wrap(new byte[] { 1, 2, 3 })).get();
+
+        Assert.assertNull(sendResult.get().getException());
+        Assert.assertEquals("hello", connection.getLastText());
+        Assert.assertArrayEquals(new byte[] { 1, 2, 3 }, connection.getLastBinary().getBytes());
+    }
+
+    @Test
+    public void asyncRemotePropagatesSendFailure() {
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-fail",
+                new QuarkusTestSupport.SimpleHandshakeRequest(Map.of(), "ws", "localhost", 80, "/ws", null));
+        QuarkusWebSocketSession session = new QuarkusWebSocketSession(connection, null);
+        QuarkusAsyncRemote asyncRemote = new QuarkusAsyncRemote(connection, session);
+        AtomicReference<SendResult> sendResult = new AtomicReference<>();
+        IllegalStateException failure = new IllegalStateException("boom");
+
+        connection.failNextSend(failure);
+        asyncRemote.sendText("hello", sendResult::set);
+
+        Assert.assertSame(failure, sendResult.get().getException());
+
+        connection.failNextSend(failure);
+        try {
+            asyncRemote.sendText("again").get();
+            Assert.fail("Expected send failure.");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Assert.fail("Interrupted while waiting for future.");
+        } catch (ExecutionException e) {
+            Assert.assertSame(failure, e.getCause());
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusWebSocketSession.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusWebSocketSession.java
@@ -1,0 +1,62 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.MessageHandler;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Test_QuarkusWebSocketSession {
+
+    @Test
+    public void sessionExposesHandshakeDataAndHandlerRegistration() {
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-session",
+                new QuarkusTestSupport.SimpleHandshakeRequest(
+                        Map.of("Cookie", List.of("auth=abc")),
+                        "wss",
+                        "example.test",
+                        443,
+                        "/socket",
+                        "client=1"));
+        QuarkusHandshakeRequest handshakeRequest = new QuarkusHandshakeRequest(connection.handshakeRequest());
+        QuarkusWebSocketSession session = new QuarkusWebSocketSession(connection, handshakeRequest);
+        MessageHandler.Whole<String> handler = message -> { };
+
+        session.addMessageHandler(handler);
+
+        Assert.assertEquals("conn-session", session.getId());
+        Assert.assertEquals("matssocket", session.getNegotiatedSubprotocol());
+        Assert.assertTrue(session.isSecure());
+        Assert.assertTrue(session.isOpen());
+        Assert.assertEquals("wss://example.test/socket?client=1", session.getRequestURI().toString());
+        Assert.assertEquals(List.of("1"), session.getRequestParameterMap().get("client"));
+        Assert.assertEquals("client=1", session.getQueryString());
+        Assert.assertEquals(1, session.getMessageHandlers().size());
+        Assert.assertSame(handler, session.getTextMessageHandler());
+        Assert.assertEquals(1, session.getOpenSessions().size());
+
+        session.removeMessageHandler(handler);
+
+        Assert.assertTrue(session.getMessageHandlers().isEmpty());
+        Assert.assertNull(session.getTextMessageHandler());
+    }
+
+    @Test
+    public void sessionClosePropagatesReasonToConnection() throws Exception {
+        QuarkusTestSupport.RecordingWebSocketConnection connection = new QuarkusTestSupport.RecordingWebSocketConnection(
+                "conn-close",
+                new QuarkusTestSupport.SimpleHandshakeRequest(Map.of(), "ws", "localhost", 80, "/socket", null));
+        QuarkusWebSocketSession session = new QuarkusWebSocketSession(connection, null);
+
+        session.close(new CloseReason(CloseReason.CloseCodes.GOING_AWAY, "restart"));
+
+        Assert.assertEquals(1, connection.getCloseCalls());
+        Assert.assertEquals(1001, connection.closeReason().getCode());
+        Assert.assertEquals("restart", connection.closeReason().getMessage());
+        Assert.assertFalse(session.isOpen());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@ gradleEnterprise {
 
 rootProject.name = 'matssocket'
 
-include 'matssocket-server-api', 'matssocket-server-impl',
+include 'matssocket-server-api', 'matssocket-server-impl', 'matssocket-server-quarkus',
         'matssocket-client-javascript', 'matssocket-client-javascript:client', 'matssocket-client-javascript:tests',
         'matssocket-client-dart',
         'js-client-consumer-canary'


### PR DESCRIPTION
Quarkus WebSockets Next adapter for MatsSocket server, plus PostgreSQL dialect support for ClusterStoreAndForward_SQL.

Tested and deployed with Quarkus 3.16.3 and PostgreSQL 16.

Known limitation: HandshakeResponse header mutations don't reach the client (Quarkus platform constraint, documented in README).