### PR TITLE
Add native PostgreSQL LIMIT support in ClusterStoreAndForward_SQL

### DIFF
--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/ClusterStoreAndForward_SQL.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/ClusterStoreAndForward_SQL.java
@@ -58,6 +58,9 @@ public class ClusterStoreAndForward_SQL implements ClusterStoreAndForward {
     // AtomicBoolean so that it can be set after construction w/o memory problems.
     private AtomicBoolean _useGetNString = new AtomicBoolean(false);
 
+    // Whether to use "SELECT ... LIMIT n" (PostgreSQL, MySQL, H2) instead of "SELECT TOP n ..." (MS SQL).
+    private AtomicBoolean _useLimitInsteadOfTop = new AtomicBoolean(false);
+
     public static ClusterStoreAndForward_SQL create(DataSource dataSource, String nodename) {
         ClusterStoreAndForward_SQL csaf = new ClusterStoreAndForward_SQL(dataSource, nodename);
         return csaf;
@@ -124,6 +127,51 @@ public class ClusterStoreAndForward_SQL implements ClusterStoreAndForward {
      */
     public void useGetNString(boolean decision) {
         _useGetNString.set(decision);
+    }
+
+    /**
+     * Convenience method that configures runtime SQL dialect based on the
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database Database} enum - the same enum used for schema
+     * migrations. This ensures that schema setup and runtime SQL stay in sync.
+     * <p>
+     * Currently sets {@link #useLimitInsteadOfTop(boolean)} to <code>true</code> for
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#POSTGRESQL POSTGRESQL},
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#MYSQL MYSQL} and
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#H2 H2}.
+     * <p>
+     * <b>Note: Oracle is not currently supported at the runtime SQL level</b> (Oracle uses
+     * {@code FETCH FIRST n ROWS ONLY}, not {@code LIMIT}). The Oracle enum values only configure schema types.
+     *
+     * @param database
+     *            the database type, as used for {@link ClusterStoreAndForward_SQL_DbMigrations}.
+     */
+    public void setDatabase(ClusterStoreAndForward_SQL_DbMigrations.Database database) {
+        switch (database) {
+            case POSTGRESQL:
+            case MYSQL:
+            case H2:
+                useLimitInsteadOfTop(true);
+                break;
+            default:
+                useLimitInsteadOfTop(false);
+        }
+    }
+
+    /**
+     * Whether to use {@code "SELECT ... LIMIT n"} instead of {@code "SELECT TOP n ..."} (MS SQL) syntax for
+     * row-limiting queries. Set this to <code>true</code> for databases that use LIMIT syntax, e.g.
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#POSTGRESQL PostgreSQL},
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#MYSQL MySQL} and
+     * {@link ClusterStoreAndForward_SQL_DbMigrations.Database#H2 H2}.
+     * <p>
+     * Consider using {@link #setDatabase(ClusterStoreAndForward_SQL_DbMigrations.Database)} instead, which configures
+     * this automatically based on the database type.
+     *
+     * @param decision
+     *            whether to use LIMIT instead of TOP syntax - default <code>false</code>.
+     */
+    public void useLimitInsteadOfTop(boolean decision) {
+        _useLimitInsteadOfTop.set(decision);
     }
 
     @Override
@@ -672,15 +720,19 @@ public class ClusterStoreAndForward_SQL implements ClusterStoreAndForward {
             throws DataAccessException {
         return withConnectionReturn(con -> {
             // The old MS JDBC Driver 'jtds' don't handle parameter insertion for 'TOP' statement.
-            PreparedStatement selectMsgs = con.prepareStatement("SELECT TOP " + maxNumberOfMessages
-                    + " smid, trace_id, type,"
+            String columns = " smid, trace_id, type,"
                     + " cmid, request_timestamp,"
                     + " stored_timestamp, delivery_count,"
-                    + " envelope, message_text, message_binary"
-                    + "  FROM " + outboxTableName(matsSocketSessionId)
+                    + " envelope, message_text, message_binary";
+            String fromWhere = "  FROM " + outboxTableName(matsSocketSessionId)
                     + " WHERE session_id = ?"
                     + "   AND attempt_timestamp IS NULL"
-                    + "   AND delivery_count <> " + DLQ_DELIVERY_COUNT_MARKER);
+                    + "   AND delivery_count <> " + DLQ_DELIVERY_COUNT_MARKER;
+            // ?: Are we using PostgreSQL LIMIT syntax?
+            String sql = _useLimitInsteadOfTop.get()
+                    ? "SELECT" + columns + fromWhere + " LIMIT " + maxNumberOfMessages
+                    : "SELECT TOP " + maxNumberOfMessages + columns + fromWhere;
+            PreparedStatement selectMsgs = con.prepareStatement(sql);
             selectMsgs.setString(1, matsSocketSessionId);
             ResultSet rs = selectMsgs.executeQuery();
             List<StoredOutMessage> list = new ArrayList<>();

--- a/matssocket-server-impl/src/test/java/io/mats3/matssocket/Test_ClusterStoreAndForward_SQL_PostgresLimitSyntax.java
+++ b/matssocket-server-impl/src/test/java/io/mats3/matssocket/Test_ClusterStoreAndForward_SQL_PostgresLimitSyntax.java
@@ -1,0 +1,224 @@
+package io.mats3.matssocket;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import javax.sql.DataSource;
+
+import org.h2.jdbcx.JdbcConnectionPool;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.mats3.MatsFactory.ContextLocal;
+import io.mats3.matssocket.ClusterStoreAndForward.StoredOutMessage;
+import io.mats3.matssocket.MatsSocketServer.MessageType;
+import io.mats3.matssocket.impl.ClusterStoreAndForward_SQL;
+import io.mats3.matssocket.impl.ClusterStoreAndForward_SQL_DbMigrations;
+import io.mats3.matssocket.impl.ClusterStoreAndForward_SQL_DbMigrations.Database;
+
+/**
+ * Tests that {@link ClusterStoreAndForward_SQL#useLimitInsteadOfTop(boolean)} correctly switches from MS SQL's
+ * {@code "SELECT TOP n .."} to PostgreSQL's {@code "SELECT .. LIMIT n"} syntax. Uses a SQL-capturing DataSource proxy
+ * to verify the actual SQL produced, since H2 accepts both syntaxes and a roundtrip-only test would not catch a no-op.
+ *
+ * @author Thor Egil Kolltveit 2026-04-10 08:14 - thoregil@kolltveit.org
+ */
+public class Test_ClusterStoreAndForward_SQL_PostgresLimitSyntax {
+
+    private static JdbcConnectionPool _dataSource;
+    private static final String SESSION_ID = "TestSession_Limit";
+    private static final String NODE_NAME = "testnode";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Initialize ContextLocal callback to return empty (no Mats stage context), so CSAF falls back to DataSource.
+        Field callbackField = ContextLocal.class.getDeclaredField("callback");
+        callbackField.setAccessible(true);
+        callbackField.set(null, (BiFunction<Class<?>, String[], Optional<?>>) (type, keys) -> Optional.empty());
+
+        JdbcDataSource h2Ds = new JdbcDataSource();
+        h2Ds.setURL("jdbc:h2:mem:Test_PostgresLimitSyntax;DB_CLOSE_DELAY=-1");
+        _dataSource = JdbcConnectionPool.create(h2Ds);
+
+        // Migrate tables
+        ClusterStoreAndForward_SQL_DbMigrations.create(Database.H2).migrateUsingFlyway(_dataSource);
+
+        // Seed session and outbox data directly via SQL (bypassing ContextLocal requirement)
+        try (Connection con = _dataSource.getConnection()) {
+            con.setAutoCommit(false);
+
+            PreparedStatement insertSession = con.prepareStatement(
+                    "INSERT INTO mats_socket_session"
+                            + " (session_id, connection_id, nodename, user_id, client_lib,"
+                            + " app_name, app_version, created_timestamp, liveliness_timestamp)"
+                            + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+            insertSession.setString(1, SESSION_ID);
+            insertSession.setString(2, "conn1");
+            insertSession.setString(3, NODE_NAME);
+            insertSession.setString(4, "TestUser");
+            insertSession.setString(5, "TestLib/1.0");
+            insertSession.setString(6, "TestApp");
+            insertSession.setString(7, "1.0");
+            insertSession.setLong(8, System.currentTimeMillis());
+            insertSession.setLong(9, System.currentTimeMillis());
+            insertSession.execute();
+
+            // Insert 3 messages into the outbox table for this session
+            int tableNum = Math.floorMod(SESSION_ID.hashCode(), 7);
+            String tableName = "mats_socket_outbox_" + (tableNum < 10 ? "0" + tableNum : tableNum);
+            for (int i = 0; i < 3; i++) {
+                PreparedStatement insert = con.prepareStatement(
+                        "INSERT INTO " + tableName
+                                + " (session_id, smid, trace_id, type, cmid, request_timestamp,"
+                                + " stored_timestamp, delivery_count, envelope, message_text)"
+                                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                insert.setString(1, SESSION_ID);
+                insert.setString(2, "smid_" + i);
+                insert.setString(3, "traceId_" + i);
+                insert.setString(4, MessageType.RESOLVE.name());
+                insert.setString(5, "cmid_" + i);
+                insert.setLong(6, System.currentTimeMillis());
+                insert.setLong(7, System.currentTimeMillis());
+                insert.setInt(8, 0);
+                insert.setString(9, "envelope_" + i);
+                insert.setString(10, "message_" + i);
+                insert.execute();
+            }
+            con.commit();
+        }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        _dataSource.dispose();
+    }
+
+    // ---- Helper: DataSource proxy that captures SQL from prepareStatement calls ----
+
+    private static DataSource capturingDataSource(DataSource delegate, List<String> capturedSql) {
+        return (DataSource) Proxy.newProxyInstance(DataSource.class.getClassLoader(),
+                new Class<?>[] { DataSource.class },
+                (proxy, method, args) -> {
+                    Object result = method.invoke(delegate, args);
+                    if ("getConnection".equals(method.getName()) && result instanceof Connection) {
+                        return capturingConnection((Connection) result, capturedSql);
+                    }
+                    return result;
+                });
+    }
+
+    private static Connection capturingConnection(Connection delegate, List<String> capturedSql) {
+        return (Connection) Proxy.newProxyInstance(Connection.class.getClassLoader(),
+                new Class<?>[] { Connection.class },
+                (proxy, method, args) -> {
+                    if ("prepareStatement".equals(method.getName()) && args != null && args[0] instanceof String) {
+                        capturedSql.add((String) args[0]);
+                    }
+                    try {
+                        return method.invoke(delegate, args);
+                    }
+                    catch (InvocationTargetException e) {
+                        throw e.getCause();
+                    }
+                });
+    }
+
+    // ---- Tests ----
+
+    /**
+     * Verify that with useLimitInsteadOfTop(true), the SQL uses LIMIT and not TOP.
+     */
+    @Test
+    public void limitSyntax_shouldEmitLimitNotTop() throws Exception {
+        List<String> capturedSql = new ArrayList<>();
+        ClusterStoreAndForward_SQL csaf = ClusterStoreAndForward_SQL.create(
+                capturingDataSource(_dataSource, capturedSql), NODE_NAME);
+        csaf.useLimitInsteadOfTop(true);
+
+        List<StoredOutMessage> messages = csaf.getMessagesFromOutbox(SESSION_ID, 2);
+        Assert.assertEquals(2, messages.size());
+
+        // Find the outbox SELECT query
+        String outboxSql = capturedSql.stream()
+                .filter(s -> s.contains("mats_socket_outbox"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No outbox SQL captured"));
+        Assert.assertTrue("SQL should contain LIMIT: " + outboxSql, outboxSql.contains("LIMIT"));
+        Assert.assertFalse("SQL should not contain TOP: " + outboxSql, outboxSql.contains("TOP"));
+    }
+
+    /**
+     * Verify that the default (no flag set) still uses TOP syntax.
+     */
+    @Test
+    public void defaultSyntax_shouldEmitTopNotLimit() throws Exception {
+        List<String> capturedSql = new ArrayList<>();
+        ClusterStoreAndForward_SQL csaf = ClusterStoreAndForward_SQL.create(
+                capturingDataSource(_dataSource, capturedSql), NODE_NAME);
+        // Note: NOT calling useLimitInsteadOfTop - default is false (TOP syntax)
+
+        List<StoredOutMessage> messages = csaf.getMessagesFromOutbox(SESSION_ID, 2);
+        Assert.assertEquals(2, messages.size());
+
+        String outboxSql = capturedSql.stream()
+                .filter(s -> s.contains("mats_socket_outbox"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No outbox SQL captured"));
+        Assert.assertTrue("SQL should contain TOP: " + outboxSql, outboxSql.contains("TOP"));
+        Assert.assertFalse("SQL should not contain LIMIT: " + outboxSql, outboxSql.contains("LIMIT"));
+    }
+
+    /**
+     * Verify that setDatabase(POSTGRESQL) configures LIMIT syntax.
+     */
+    @Test
+    public void setDatabase_postgresql_shouldEmitLimit() throws Exception {
+        List<String> capturedSql = new ArrayList<>();
+        ClusterStoreAndForward_SQL csaf = ClusterStoreAndForward_SQL.create(
+                capturingDataSource(_dataSource, capturedSql), NODE_NAME);
+        csaf.setDatabase(Database.POSTGRESQL);
+
+        List<StoredOutMessage> messages = csaf.getMessagesFromOutbox(SESSION_ID, 2);
+        Assert.assertEquals(2, messages.size());
+
+        String outboxSql = capturedSql.stream()
+                .filter(s -> s.contains("mats_socket_outbox"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No outbox SQL captured"));
+        Assert.assertTrue("SQL should contain LIMIT: " + outboxSql, outboxSql.contains("LIMIT"));
+        Assert.assertFalse("SQL should not contain TOP: " + outboxSql, outboxSql.contains("TOP"));
+    }
+
+    /**
+     * Verify that setDatabase(MS_SQL_UTF8) keeps TOP syntax.
+     */
+    @Test
+    public void setDatabase_mssql_shouldEmitTop() throws Exception {
+        List<String> capturedSql = new ArrayList<>();
+        ClusterStoreAndForward_SQL csaf = ClusterStoreAndForward_SQL.create(
+                capturingDataSource(_dataSource, capturedSql), NODE_NAME);
+        csaf.setDatabase(Database.MS_SQL_UTF8);
+
+        List<StoredOutMessage> messages = csaf.getMessagesFromOutbox(SESSION_ID, 2);
+        Assert.assertEquals(2, messages.size());
+
+        String outboxSql = capturedSql.stream()
+                .filter(s -> s.contains("mats_socket_outbox"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No outbox SQL captured"));
+        Assert.assertTrue("SQL should contain TOP: " + outboxSql, outboxSql.contains("TOP"));
+        Assert.assertFalse("SQL should not contain LIMIT: " + outboxSql, outboxSql.contains("LIMIT"));
+    }
+}


### PR DESCRIPTION
Adds useLimitInsteadOfTop() and setDatabase() to ClusterStoreAndForward_SQL, replacing the need for a DataSource proxy wrapper.

I contribute this material in accordance with Glimte's signed SCA.