### PR TITLE
Add transport session abstraction + Quarkus WebSockets Next adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ tasks.named("dependencyUpdates").configure {
     }
 }
 
-// Common config for the two Java subprojects
-configure([project('matssocket-server-api'), project('matssocket-server-impl')]) {
+// Common config for the Java server subprojects
+configure([project('matssocket-server-api'), project('matssocket-server-impl'), project('matssocket-server-quarkus')]) {
     apply plugin: 'java-library'
     apply plugin: "com.vanniktech.maven.publish"
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ ext {
     logbackVersion = '1.5.20'
     h2Version = '2.4.240'
     jettyVersion = '12.1.3'
+    quarkusVersion = '3.16.3'
 
     // Build tools: Dart SDK and Node.js
     dartSdkVersion = '3.9.4'

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -266,6 +266,59 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
         }
     }
 
+    /**
+     * Jakarta WebSocket implementation of {@link MatsSocketTransportSession}, wrapping a real {@link Session}.
+     */
+    static class JakartaTransportSession implements MatsSocketTransportSession {
+        private final Session _jakartaSession;
+        private final jakarta.websocket.RemoteEndpoint.Basic _basicRemote;
+
+        JakartaTransportSession(Session jakartaSession) {
+            _jakartaSession = jakartaSession;
+            _basicRemote = jakartaSession.getBasicRemote();
+        }
+
+        @Override
+        public String getId() {
+            return _jakartaSession.getId();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return _jakartaSession.isOpen();
+        }
+
+        @Override
+        public void sendText(String text) throws IOException {
+            _basicRemote.sendText(text);
+        }
+
+        @Override
+        public void close(int closeCode, String reasonPhrase) throws IOException {
+            _jakartaSession.close(new CloseReason(() -> closeCode, reasonPhrase));
+        }
+
+        @Override
+        public void setMaxIdleTimeout(long millis) {
+            _jakartaSession.setMaxIdleTimeout(millis);
+        }
+
+        @Override
+        public void setMaxTextMessageBufferSize(int size) {
+            _jakartaSession.setMaxTextMessageBufferSize(size);
+        }
+
+        @Override
+        public void setMaxBinaryMessageBufferSize(int size) {
+            _jakartaSession.setMaxBinaryMessageBufferSize(size);
+        }
+
+        @Override
+        public Session getJakartaSessionView() {
+            return _jakartaSession;
+        }
+    }
+
     // Constructor init
     private final MatsFactory _matsFactory;
     private final String _instanceName;

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -1178,12 +1178,21 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
             // :: Try to get Remote Address
             String remoteAddr = RemoteAddressContainerHacks.attemptGetRemoteAddress(session);
 
-            // :: Create the MatsSocketSession - which also is the WebSocket MessageHandler.
-            _matsSocketSessionAndMessageHandler = new MatsSocketSessionAndMessageHandler(_matsSocketServer, session,
-                    _connectionId, _handshakeRequestResponse._handshakeRequest, _sessionAuthenticator, remoteAddr);
+            // :: Wrap Session in transport abstraction
+            JakartaTransportSession transportSession = new JakartaTransportSession(session);
+
+            // :: Create the MatsSocketSession
+            _matsSocketSessionAndMessageHandler = new MatsSocketSessionAndMessageHandler(_matsSocketServer,
+                    transportSession, _connectionId, _handshakeRequestResponse._handshakeRequest,
+                    _sessionAuthenticator, remoteAddr);
 
             // :: Register it as the MessageHandler
-            session.addMessageHandler(_matsSocketSessionAndMessageHandler);
+            session.addMessageHandler(new jakarta.websocket.MessageHandler.Whole<String>() {
+                @Override
+                public void onMessage(String message) {
+                    _matsSocketSessionAndMessageHandler.onMessage(message);
+                }
+            });
         }
 
         @Override

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -135,6 +135,21 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
     }
 
     /**
+     * Create a {@link DefaultMatsSocketServer} without Jakarta WebSocket endpoint registration. Intended for
+     * alternative transports (e.g. Quarkus WebSockets Next) that handle their own WebSocket lifecycle and call
+     * {@link #configurePreAuthSession}, {@link #createSessionHandlerAfterAuth}, {@link #handleTransportError}
+     * and {@link #handleTransportClose} directly.
+     */
+    public static DefaultMatsSocketServer createForExternalTransport(
+            MatsFactory matsFactory,
+            ClusterStoreAndForward clusterStoreAndForward,
+            AuthenticationPlugin authenticationPlugin,
+            String instanceName) {
+        clusterStoreAndForward.boot();
+        return new DefaultMatsSocketServer(matsFactory, clusterStoreAndForward, instanceName, authenticationPlugin);
+    }
+
+    /**
      * Create a MatsSocketServer, piecing together necessary bits.
      *
      * @param serverContainer
@@ -458,6 +473,11 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
     }
 
     private volatile boolean _stopped = false;
+
+    /** @return whether this server has been stopped (for external transport guards). */
+    public boolean isStopped() {
+        return _stopped;
+    }
 
     String getMyNodename() {
         return _matsFactory.getFactoryConfig().getNodename();
@@ -1124,7 +1144,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      * Creates a {@link MatsSocketSessionAndMessageHandler} after authentication has passed. The transport/Jakarta
      * endpoint has already called checkOrigin, checkHandshake and sessionAuthenticator.onOpen.
      */
-    public MatsSocketSessionAndMessageHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
+    public MatsSocketTransportHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
             String connectionId, HandshakeRequest handshakeRequest, SessionAuthenticator sessionAuthenticator,
             String remoteAddr) {
         return new MatsSocketSessionAndMessageHandler(this, transportSession, connectionId, handshakeRequest,
@@ -1136,7 +1156,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      *
      * @return whether this was a timeout exception (needed by close handling).
      */
-    public static boolean handleTransportError(MatsSocketSessionAndMessageHandler handler,
+    public static boolean handleTransportError(MatsSocketTransportHandler handler,
             MatsSocketTransportSession session, Throwable thr) {
         try { // finally: MDC.clear()
             if (handler != null) {
@@ -1171,7 +1191,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      * Handles a transport-level close. Extracted from {@code MatsWebSocketEndpointInstance.onClose()}. Decides whether
      * to close the MatsSocket session or just deregister it based on the close code.
      */
-    public static void handleTransportClose(MatsSocketSessionAndMessageHandler handler, MatsSocketTransportSession session,
+    public static void handleTransportClose(MatsSocketTransportHandler handler, MatsSocketTransportSession session,
             String connectionId, int closeCode, String reason, boolean isTimeout) {
         try { // finally: MDC.clear()
             if (handler != null) {
@@ -1246,7 +1266,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
 
         // Will be set when onOpen is invoked
         private String _connectionId;
-        private MatsSocketSessionAndMessageHandler _matsSocketSessionAndMessageHandler;
+        private MatsSocketTransportHandler _matsSocketSessionAndMessageHandler;
 
         public MatsWebSocketEndpointInstance(DefaultMatsSocketServer matsSocketServer,
                 SessionAuthenticator sessionAuthenticator,

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -310,7 +310,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
 
         @Override
         public void close(int closeCode, String reasonPhrase) throws IOException {
-            _jakartaSession.close(new CloseReason(() -> closeCode, reasonPhrase));
+            _jakartaSession.close(new CloseReason(MatsSocketCloseCodes.getCloseCode(closeCode), reasonPhrase));
         }
 
         @Override

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -1141,8 +1141,8 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
     }
 
     /**
-     * Creates a {@link MatsSocketSessionAndMessageHandler} after authentication has passed. The transport/Jakarta
-     * endpoint has already called checkOrigin, checkHandshake and sessionAuthenticator.onOpen.
+     * Creates a {@link MatsSocketTransportHandler} after authentication has passed. The transport/Jakarta endpoint has
+     * already called checkOrigin, checkHandshake and sessionAuthenticator.onOpen.
      */
     public MatsSocketTransportHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
             String connectionId, HandshakeRequest handshakeRequest, SessionAuthenticator sessionAuthenticator,
@@ -1266,6 +1266,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
 
         // Will be set when onOpen is invoked
         private String _connectionId;
+        private JakartaTransportSession _transportSession;
         private MatsSocketTransportHandler _matsSocketSessionAndMessageHandler;
 
         public MatsWebSocketEndpointInstance(DefaultMatsSocketServer matsSocketServer,
@@ -1291,24 +1292,24 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
             _connectionId = session.getId() + "_" + rnd(6);
 
             // :: Wrap Session in transport abstraction
-            JakartaTransportSession transportSession = new JakartaTransportSession(session);
+            _transportSession = new JakartaTransportSession(session);
 
             // ?: If we are going down, then immediately close it.
             if (_matsSocketServer._stopped) {
-                closeTransportSession(transportSession, MatsSocketCloseCodes.SERVICE_RESTART.getCode(),
+                closeTransportSession(_transportSession, MatsSocketCloseCodes.SERVICE_RESTART.getCode(),
                         "This server is going down, perform a (re)connect to another instance.");
                 return;
             }
 
             // :: Set low pre-HELLO limits
-            _matsSocketServer.configurePreAuthSession(transportSession);
+            _matsSocketServer.configurePreAuthSession(_transportSession);
 
             try {
                 boolean ok = _sessionAuthenticator.onOpen(session, (ServerEndpointConfig) config);
                 log.info("webSocket.onOpen(..): Asked SessionAuthenticator.onOpen(..), returned: "
                         + (ok ? "OK" : "NOT OK!"));
                 if (!ok) {
-                    closeTransportSession(transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                    closeTransportSession(_transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
                             "SessionAuthenticator did not want this session to proceed");
                     return;
                 }
@@ -1316,7 +1317,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
             catch (Throwable t) {
                 log.error("webSocket.onOpen(..): Got throwable when invoking SessionAuthenticator.onOpen(..)."
                         + " Closing WebSocket.", t);
-                closeTransportSession(transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                closeTransportSession(_transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
                         "SessionAuthenticator did not want this session to proceed");
                 return;
             }
@@ -1326,7 +1327,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
 
             // :: Create the MatsSocketSession
             _matsSocketSessionAndMessageHandler = _matsSocketServer.createSessionHandlerAfterAuth(
-                    transportSession, _connectionId, _handshakeRequestResponse._handshakeRequest,
+                    _transportSession, _connectionId, _handshakeRequestResponse._handshakeRequest,
                     _sessionAuthenticator, remoteAddr);
 
             // :: Register it as the MessageHandler
@@ -1341,18 +1342,20 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
         @Override
         public void onError(Session session, Throwable thr) {
             _isTimeoutException = handleTransportError(_matsSocketSessionAndMessageHandler,
-                    new JakartaTransportSession(session), thr);
+                    getOrCreateTransportSession(session), thr);
         }
 
         @Override
         public void onClose(Session session, CloseReason closeReason) {
-            handleTransportClose(_matsSocketSessionAndMessageHandler, new JakartaTransportSession(session),
+            handleTransportClose(_matsSocketSessionAndMessageHandler, getOrCreateTransportSession(session),
                     _connectionId, closeReason.getCloseCode().getCode(), closeReason.getReasonPhrase(),
                     _isTimeoutException);
         }
-    }
 
-    // Note: Old closeWebSocket(Session, CloseCode, String) removed - replaced by closeTransportSession(...).
+        private JakartaTransportSession getOrCreateTransportSession(Session session) {
+            return _transportSession != null ? _transportSession : new JakartaTransportSession(session);
+        }
+    }
 
     /**
      * Registrations of MatsSocketEndpoint - these are the definitions of which targets a MatsSocket client can send

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -1111,7 +1111,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      * Sets low pre-HELLO limits on the transport session. Must be called before
      * {@code SessionAuthenticator.onOpen(...)}.
      */
-    void configurePreAuthSession(MatsSocketTransportSession session) {
+    public void configurePreAuthSession(MatsSocketTransportSession session) {
         // We do not (yet) handle binary messages, so limit that pretty hard.
         session.setMaxBinaryMessageBufferSize(1024);
         // Set low limits for the HELLO message, 20KiB should be plenty even for quite large Oauth2 bearer tokens.
@@ -1124,7 +1124,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      * Creates a {@link MatsSocketSessionAndMessageHandler} after authentication has passed. The transport/Jakarta
      * endpoint has already called checkOrigin, checkHandshake and sessionAuthenticator.onOpen.
      */
-    MatsSocketSessionAndMessageHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
+    public MatsSocketSessionAndMessageHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
             String connectionId, HandshakeRequest handshakeRequest, SessionAuthenticator sessionAuthenticator,
             String remoteAddr) {
         return new MatsSocketSessionAndMessageHandler(this, transportSession, connectionId, handshakeRequest,
@@ -1136,7 +1136,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      *
      * @return whether this was a timeout exception (needed by close handling).
      */
-    static boolean handleTransportError(MatsSocketSessionAndMessageHandler handler,
+    public static boolean handleTransportError(MatsSocketSessionAndMessageHandler handler,
             MatsSocketTransportSession session, Throwable thr) {
         try { // finally: MDC.clear()
             if (handler != null) {
@@ -1171,7 +1171,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
      * Handles a transport-level close. Extracted from {@code MatsWebSocketEndpointInstance.onClose()}. Decides whether
      * to close the MatsSocket session or just deregister it based on the close code.
      */
-    static void handleTransportClose(MatsSocketSessionAndMessageHandler handler, MatsSocketTransportSession session,
+    public static void handleTransportClose(MatsSocketSessionAndMessageHandler handler, MatsSocketTransportSession session,
             String connectionId, int closeCode, String reason, boolean isTimeout) {
         try { // finally: MDC.clear()
             if (handler != null) {
@@ -1217,7 +1217,7 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
     /**
      * Closes a WebSocket transport session with reason truncation to fit WebSocket close frame limits.
      */
-    static void closeTransportSession(MatsSocketTransportSession session, int closeCode, String reasonPhrase) {
+    public static void closeTransportSession(MatsSocketTransportSession session, int closeCode, String reasonPhrase) {
         log.info("Closing WebSocket SessionId [" + session.getId() + "]: code: [" + closeCode
                 + "], reason:[" + reasonPhrase + "]");
         try {

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/DefaultMatsSocketServer.java
@@ -1105,6 +1105,133 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
         return Optional.ofNullable(registration);
     }
 
+    // ====== Transport-neutral lifecycle helpers ======
+
+    /**
+     * Sets low pre-HELLO limits on the transport session. Must be called before
+     * {@code SessionAuthenticator.onOpen(...)}.
+     */
+    void configurePreAuthSession(MatsSocketTransportSession session) {
+        // We do not (yet) handle binary messages, so limit that pretty hard.
+        session.setMaxBinaryMessageBufferSize(1024);
+        // Set low limits for the HELLO message, 20KiB should be plenty even for quite large Oauth2 bearer tokens.
+        session.setMaxTextMessageBufferSize(20 * 1024);
+        // Set low time to say HELLO after the connect. (The default clients say it immediately on "onopen".)
+        session.setMaxIdleTimeout(5000);
+    }
+
+    /**
+     * Creates a {@link MatsSocketSessionAndMessageHandler} after authentication has passed. The transport/Jakarta
+     * endpoint has already called checkOrigin, checkHandshake and sessionAuthenticator.onOpen.
+     */
+    MatsSocketSessionAndMessageHandler createSessionHandlerAfterAuth(MatsSocketTransportSession transportSession,
+            String connectionId, HandshakeRequest handshakeRequest, SessionAuthenticator sessionAuthenticator,
+            String remoteAddr) {
+        return new MatsSocketSessionAndMessageHandler(this, transportSession, connectionId, handshakeRequest,
+                sessionAuthenticator, remoteAddr);
+    }
+
+    /**
+     * Handles a transport-level error. Extracted from {@code MatsWebSocketEndpointInstance.onError()}.
+     *
+     * @return whether this was a timeout exception (needed by close handling).
+     */
+    static boolean handleTransportError(MatsSocketSessionAndMessageHandler handler,
+            MatsSocketTransportSession session, Throwable thr) {
+        try { // finally: MDC.clear()
+            if (handler != null) {
+                handler.setMDC();
+            }
+
+            // Deduce if this is a Server side timeout
+            // Note: This is modelled after Jetty. If different with other JSR 356 implementations, please expand.
+            boolean isTimeout = (thr.getCause() instanceof TimeoutException
+                    || ((thr.getMessage() != null) && thr.getMessage().toLowerCase().contains("timeout expired")));
+
+            // ?: Is it a timeout situation?
+            if (isTimeout) {
+                log.info("WebSocket @OnError: WebSocket server timed out the connection. MatsSocket SessionId: ["
+                        + (handler == null ? "no MatsSocketSession" : handler.getMatsSocketSessionId())
+                        + "], WebSocket SessionId:" + session.getId());
+            }
+            else {
+                log.warn("WebSocket @OnError, MatsSocket SessionId: ["
+                        + (handler == null ? "no MatsSocketSession" : handler.getMatsSocketSessionId())
+                        + "], WebSocket SessionId:" + session.getId(),
+                        new Exception("MatsSocketServer's webSocket.onError(..) handler", thr));
+            }
+            return isTimeout;
+        }
+        finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Handles a transport-level close. Extracted from {@code MatsWebSocketEndpointInstance.onClose()}. Decides whether
+     * to close the MatsSocket session or just deregister it based on the close code.
+     */
+    static void handleTransportClose(MatsSocketSessionAndMessageHandler handler, MatsSocketTransportSession session,
+            String connectionId, int closeCode, String reason, boolean isTimeout) {
+        try { // finally: MDC.clear()
+            if (handler != null) {
+                handler.setMDC();
+            }
+            log.info("WebSocket @OnClose, code:[" + MatsSocketCloseCodes.getCloseCode(closeCode)
+                    + "] (timeout:[" + isTimeout + "]), reason:[" + reason
+                    + "], MatsSocket SessionId: [" + (handler == null
+                            ? "no MatsSocketSession" : handler.getMatsSocketSessionId())
+                    + "], ConnectionId:" + connectionId);
+
+            // ?: Have we gotten MatsSocketSession yet?
+            if (handler != null) {
+                // -> Yes, so either close session, or just deregister us from local and CSAF
+                boolean goingAwayFromClientSide = (MatsSocketCloseCodes.GOING_AWAY.getCode() == closeCode)
+                        && (!isTimeout);
+                // ?: Did the client or Server want to actually Close Session?
+                if ((MatsSocketCloseCodes.UNEXPECTED_CONDITION.getCode() == closeCode)
+                        || (MatsSocketCloseCodes.MATS_SOCKET_PROTOCOL_ERROR.getCode() == closeCode)
+                        || (MatsSocketCloseCodes.VIOLATED_POLICY.getCode() == closeCode)
+                        || (MatsSocketCloseCodes.CLOSE_SESSION.getCode() == closeCode)
+                        || (MatsSocketCloseCodes.SESSION_LOST.getCode() == closeCode)
+                        || goingAwayFromClientSide) {
+                    log.info("Explicitly Closed MatsSocketSession due to CloseCode ["
+                            + MatsSocketCloseCodes.getCloseCode(closeCode)
+                            + "] (timeout:[" + isTimeout + "]), actually closing (terminating) it.");
+                    handler.closeSession(closeCode, reason);
+                }
+                else {
+                    log.info("Got a non-closing CloseCode [" + MatsSocketCloseCodes.getCloseCode(closeCode)
+                            + "] (timeout:[" + isTimeout
+                            + "]), assuming that Client might want to reconnect - deregistering"
+                            + " MatsSocketSession from CSAF.");
+                    handler.deregisterSession(closeCode, reason);
+                }
+            }
+        }
+        finally {
+            MDC.clear();
+        }
+    }
+
+    /**
+     * Closes a WebSocket transport session with reason truncation to fit WebSocket close frame limits.
+     */
+    static void closeTransportSession(MatsSocketTransportSession session, int closeCode, String reasonPhrase) {
+        log.info("Closing WebSocket SessionId [" + session.getId() + "]: code: [" + closeCode
+                + "], reason:[" + reasonPhrase + "]");
+        try {
+            while (reasonPhrase != null && reasonPhrase.getBytes(StandardCharsets.UTF_8).length > 123) {
+                reasonPhrase = reasonPhrase.substring(0, reasonPhrase.length() - 1);
+            }
+            session.close(closeCode, reasonPhrase);
+        }
+        catch (IOException e) {
+            log.warn("Got Exception when trying to close WebSocket SessionId [" + session.getId()
+                    + "], ignoring.", e);
+        }
+    }
+
     /**
      * Shall be one instance per socket (i.e. from the docs: "..there will be precisely one endpoint instance per active
      * client connection"), thus there will be 1:1 correlation between this instance and the single Session object for
@@ -1143,46 +1270,42 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
             // Notice: On a particular server, the session.getId() is already unique. On Jetty: integer sequence.
             _connectionId = session.getId() + "_" + rnd(6);
 
+            // :: Wrap Session in transport abstraction
+            JakartaTransportSession transportSession = new JakartaTransportSession(session);
+
             // ?: If we are going down, then immediately close it.
             if (_matsSocketServer._stopped) {
-                closeWebSocket(session, MatsSocketCloseCodes.SERVICE_RESTART,
+                closeTransportSession(transportSession, MatsSocketCloseCodes.SERVICE_RESTART.getCode(),
                         "This server is going down, perform a (re)connect to another instance.");
                 return;
             }
 
-            // We do not (yet) handle binary messages, so limit that pretty hard.
-            session.setMaxBinaryMessageBufferSize(1024);
-            // Set low limits for the HELLO message, 20KiB should be plenty even for quite large Oauth2 bearer tokens.
-            session.setMaxTextMessageBufferSize(20 * 1024);
-            // Set low time to say HELLO after the connect. (The default clients say it immediately on "onopen".)
-            session.setMaxIdleTimeout(5000);
+            // :: Set low pre-HELLO limits
+            _matsSocketServer.configurePreAuthSession(transportSession);
 
             try {
                 boolean ok = _sessionAuthenticator.onOpen(session, (ServerEndpointConfig) config);
                 log.info("webSocket.onOpen(..): Asked SessionAuthenticator.onOpen(..), returned: "
                         + (ok ? "OK" : "NOT OK!"));
                 if (!ok) {
-                    closeWebSocket(session, MatsSocketCloseCodes.VIOLATED_POLICY, "SessionAuthenticator did not want"
-                            + " this session to proceed");
+                    closeTransportSession(transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                            "SessionAuthenticator did not want this session to proceed");
                     return;
                 }
             }
             catch (Throwable t) {
                 log.error("webSocket.onOpen(..): Got throwable when invoking SessionAuthenticator.onOpen(..)."
                         + " Closing WebSocket.", t);
-                closeWebSocket(session, MatsSocketCloseCodes.VIOLATED_POLICY, "SessionAuthenticator did not want this"
-                        + " session to proceed");
+                closeTransportSession(transportSession, MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                        "SessionAuthenticator did not want this session to proceed");
                 return;
             }
 
             // :: Try to get Remote Address
             String remoteAddr = RemoteAddressContainerHacks.attemptGetRemoteAddress(session);
 
-            // :: Wrap Session in transport abstraction
-            JakartaTransportSession transportSession = new JakartaTransportSession(session);
-
             // :: Create the MatsSocketSession
-            _matsSocketSessionAndMessageHandler = new MatsSocketSessionAndMessageHandler(_matsSocketServer,
+            _matsSocketSessionAndMessageHandler = _matsSocketServer.createSessionHandlerAfterAuth(
                     transportSession, _connectionId, _handshakeRequestResponse._handshakeRequest,
                     _sessionAuthenticator, remoteAddr);
 
@@ -1197,113 +1320,19 @@ public class DefaultMatsSocketServer implements MatsSocketServer, MatsSocketStat
 
         @Override
         public void onError(Session session, Throwable thr) {
-            try { // finally: MDC.clear()
-                if (_matsSocketSessionAndMessageHandler != null) {
-                    _matsSocketSessionAndMessageHandler.setMDC();
-                }
-
-                // Deduce if this is a Server side timeout
-                // Note: This is modelled after Jetty. If different with other JSR 356 implementations, please expand.
-                _isTimeoutException = (thr.getCause() instanceof TimeoutException
-                        || ((thr.getMessage() != null) && thr.getMessage().toLowerCase().contains("timeout expired")));
-
-                // ?: Is it a timeout situation?
-                if (_isTimeoutException) {
-                    // -> Yes, timeout. This is handled, and does not constitute a "close session", client might
-                    // just have lost connection and want's to reconnect soon. Just log info.
-                    log.info("WebSocket @OnError: WebSocket server timed out the connection. MatsSocket SessionId: ["
-                            + (_matsSocketSessionAndMessageHandler == null
-                                    ? "no MatsSocketSession"
-                                    : _matsSocketSessionAndMessageHandler.getMatsSocketSessionId())
-                            + "], WebSocket SessionId:" + session.getId() + ", this:" + id(this));
-                }
-                else {
-                    // -> No, not timeout. So this is some kind of unexpected situation, typically raised from the
-                    // MastSocket implementation on MessageHandler. Log warn. This will close the session.
-                    log.warn("WebSocket @OnError, MatsSocket SessionId: ["
-                            + (_matsSocketSessionAndMessageHandler == null
-                                    ? "no MatsSocketSession"
-                                    : _matsSocketSessionAndMessageHandler.getMatsSocketSessionId())
-                            + "], WebSocket SessionId:" + session.getId() + ", this:" + id(this),
-                            new Exception("MatsSocketServer's webSocket.onError(..) handler", thr));
-                }
-            }
-            finally {
-                MDC.clear();
-            }
+            _isTimeoutException = handleTransportError(_matsSocketSessionAndMessageHandler,
+                    new JakartaTransportSession(session), thr);
         }
 
         @Override
         public void onClose(Session session, CloseReason closeReason) {
-            try { // finally: MDC.clear()
-                if (_matsSocketSessionAndMessageHandler != null) {
-                    _matsSocketSessionAndMessageHandler.setMDC();
-                }
-                log.info("WebSocket @OnClose, code:[" + MatsSocketCloseCodes.getCloseCode(closeReason.getCloseCode()
-                        .getCode()) + "] (timeout:[" + _isTimeoutException + "]), reason:[" + closeReason
-                                .getReasonPhrase()
-                        + "], MatsSocket SessionId: [" + (_matsSocketSessionAndMessageHandler == null
-                                ? "no MatsSocketSession"
-                                : _matsSocketSessionAndMessageHandler.getMatsSocketSessionId())
-                        + "], ConnectionId:" + _connectionId + ", this:" + id(this));
-
-                // ?: Have we gotten MatsSocketSession yet?
-                // (Just in case "onOpen" has not been invoked yet. Can it happen?!).
-                if (_matsSocketSessionAndMessageHandler != null) {
-                    // -> Yes, so either close session, or just deregister us from local and CSAF
-                    // Is this a GOING_AWAY that is NOT from the server side? (Jetty gives this on timeout)
-                    boolean goingAwayFromClientSide = (MatsSocketCloseCodes.GOING_AWAY.getCode() == closeReason
-                            .getCloseCode().getCode()) && (!_isTimeoutException);
-                    // ?: Did the client or Server want to actually Close Session?
-                    // NOTE: Need to check by the 'code' integers, since no real enum (CloseCode is an interface).
-                    if ((MatsSocketCloseCodes.UNEXPECTED_CONDITION.getCode() == closeReason.getCloseCode().getCode())
-                            || (MatsSocketCloseCodes.MATS_SOCKET_PROTOCOL_ERROR.getCode() == closeReason.getCloseCode()
-                                    .getCode())
-                            || (MatsSocketCloseCodes.VIOLATED_POLICY.getCode() == closeReason.getCloseCode().getCode())
-                            || (MatsSocketCloseCodes.CLOSE_SESSION.getCode() == closeReason.getCloseCode().getCode())
-                            || (MatsSocketCloseCodes.SESSION_LOST.getCode() == closeReason.getCloseCode().getCode())
-                            || goingAwayFromClientSide) {
-                        // -> Yes, this was a one of the actual-close CloseCodes, or a "GOING AWAY" that was NOT
-                        // initiated from server side, which means that we should actually close this session
-                        log.info("Explicitly Closed MatsSocketSession due to CloseCode ["
-                                + MatsSocketCloseCodes.getCloseCode(closeReason.getCloseCode().getCode())
-                                + "] (timeout:[" + _isTimeoutException + "]), actually closing (terminating) it.");
-                        // Close MatsSocketSession
-                        _matsSocketSessionAndMessageHandler.closeSession(closeReason.getCloseCode().getCode(),
-                                closeReason.getReasonPhrase());
-                    }
-                    else {
-                        // -> No, this was a broken connection, or something else like an explicit disconnect w/o close
-                        log.info("Got a non-closing CloseCode [" + MatsSocketCloseCodes.getCloseCode(closeReason
-                                .getCloseCode().getCode()) + "] (timeout:[" + _isTimeoutException
-                                + "]), assuming that Client might want to reconnect - deregistering"
-                                + " MatsSocketSession from CSAF.");
-                        // Deregister MatsSocketSession
-                        _matsSocketSessionAndMessageHandler.deregisterSession(closeReason.getCloseCode().getCode(),
-                                closeReason.getReasonPhrase());
-                    }
-                }
-            }
-            finally {
-                MDC.clear();
-            }
+            handleTransportClose(_matsSocketSessionAndMessageHandler, new JakartaTransportSession(session),
+                    _connectionId, closeReason.getCloseCode().getCode(), closeReason.getReasonPhrase(),
+                    _isTimeoutException);
         }
     }
 
-    static void closeWebSocket(Session webSocketSession, CloseCode closeCode, String reasonPhrase) {
-        log.info("Closing WebSocket SessionId [" + webSocketSession.getId() + "]: code: [" + closeCode
-                + "(" + closeCode.getCode() + ")], reason:[" + reasonPhrase + "]");
-        try {
-            while (reasonPhrase != null && reasonPhrase.getBytes(StandardCharsets.UTF_8).length > 123) {
-                reasonPhrase = reasonPhrase.substring(0, reasonPhrase.length() - 1);
-            }
-            webSocketSession.close(new CloseReason(closeCode, reasonPhrase));
-        }
-        catch (IOException e) {
-            log.warn("Got Exception when trying to close WebSocket SessionId [" + webSocketSession.getId()
-                    + "], ignoring.", e);
-        }
-    }
+    // Note: Old closeWebSocket(Session, CloseCode, String) removed - replaced by closeTransportSession(...).
 
     /**
      * Registrations of MatsSocketEndpoint - these are the definitions of which targets a MatsSocket client can send

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -71,7 +71,8 @@ import tools.jackson.databind.ObjectWriter;
  *
  * @author Endre Stølsvik 2019-11-28 12:17 - http://stolsvik.com/, endre@stolsvik.com
  */
-class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession, MatsSocketTransportHandler {
+class MatsSocketSessionAndMessageHandler
+        implements MatsSocketStatics, LiveMatsSocketSession, MatsSocketTransportHandler {
     private static final Logger log = LoggerFactory.getLogger(MatsSocketSessionAndMessageHandler.class);
 
     // ===== Set in constructor

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -1050,7 +1050,7 @@ class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsS
         closeSession(closeCode.getCode(), reason);
 
         // :: Close the actual WebSocket
-        DefaultMatsSocketServer.closeWebSocket(_transportSession.getJakartaSessionView(), closeCode, reason);
+        DefaultMatsSocketServer.closeTransportSession(_transportSession, closeCode.getCode(), reason);
     }
 
     /**
@@ -1093,7 +1093,7 @@ class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsS
         deregisterSession(closeCode.getCode(), reason);
 
         // Close WebSocket
-        DefaultMatsSocketServer.closeWebSocket(_transportSession.getJakartaSessionView(), closeCode, reason);
+        DefaultMatsSocketServer.closeTransportSession(_transportSession, closeCode.getCode(), reason);
     }
 
     private void commonDeregisterAndClose(MatsSocketSessionState state, Integer closeCode, String reason) {

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -71,7 +71,7 @@ import tools.jackson.databind.ObjectWriter;
  *
  * @author Endre Stølsvik 2019-11-28 12:17 - http://stolsvik.com/, endre@stolsvik.com
  */
-public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession {
+class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession, MatsSocketTransportHandler {
     private static final Logger log = LoggerFactory.getLogger(MatsSocketSessionAndMessageHandler.class);
 
     // ===== Set in constructor
@@ -369,7 +369,8 @@ public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, Li
     private boolean _askedClientForReauth = false;
     private int _numberOfInformationBearingIncomingWhileWaitingForReauth = 0;
 
-    void setMDC() {
+    @Override
+    public void setMDC() {
         if (_matsSocketSessionId != null) {
             MDC.put(MDC_SESSION_ID, _matsSocketSessionId);
         }
@@ -415,6 +416,7 @@ public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, Li
         _matsSocketServer.invokeMessageEventListeners(this, envelopes);
     }
 
+    @Override
     public void onMessage(String message) {
         // Record start of handling
         long receivedTimestamp = System.currentTimeMillis();
@@ -1013,7 +1015,8 @@ public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, Li
      * <li>FINALLY: Notifies SessionRemovedEventListeners</li>
      * </ul>
      */
-    void closeSession(Integer closeCode, String reason) {
+    @Override
+    public void closeSession(Integer closeCode, String reason) {
         // ?: Are we already DEREGISTERD or CLOSED?
         if (!_state.isHandlesMessages()) {
             // Already deregistered or closed.
@@ -1057,7 +1060,8 @@ public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, Li
      * Deregisters session: Same as {@link #closeSession(Integer, String)}, only where it says "close", it now says
      * "deregisters".
      */
-    void deregisterSession(Integer closeCode, String reason) {
+    @Override
+    public void deregisterSession(Integer closeCode, String reason) {
         // ?: Are we already DEREGISTERD or CLOSED?
         if (!_state.isHandlesMessages()) {
             // Already deregistered or closed.

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -71,7 +71,7 @@ import tools.jackson.databind.ObjectWriter;
  *
  * @author Endre Stølsvik 2019-11-28 12:17 - http://stolsvik.com/, endre@stolsvik.com
  */
-class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession {
+public class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession {
     private static final Logger log = LoggerFactory.getLogger(MatsSocketSessionAndMessageHandler.class);
 
     // ===== Set in constructor
@@ -415,7 +415,7 @@ class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsS
         _matsSocketServer.invokeMessageEventListeners(this, envelopes);
     }
 
-    void onMessage(String message) {
+    public void onMessage(String message) {
         // Record start of handling
         long receivedTimestamp = System.currentTimeMillis();
         long nanosStart = System.nanoTime();

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketSessionAndMessageHandler.java
@@ -35,8 +35,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import jakarta.websocket.MessageHandler.Whole;
-import jakarta.websocket.RemoteEndpoint.Basic;
 import jakarta.websocket.Session;
 import jakarta.websocket.server.HandshakeRequest;
 
@@ -73,20 +71,19 @@ import tools.jackson.databind.ObjectWriter;
  *
  * @author Endre Stølsvik 2019-11-28 12:17 - http://stolsvik.com/, endre@stolsvik.com
  */
-class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketStatics, LiveMatsSocketSession {
+class MatsSocketSessionAndMessageHandler implements MatsSocketStatics, LiveMatsSocketSession {
     private static final Logger log = LoggerFactory.getLogger(MatsSocketSessionAndMessageHandler.class);
 
     // ===== Set in constructor
 
     // :: From params
     private final DefaultMatsSocketServer _matsSocketServer;
-    private final Session _webSocketSession;
+    private final MatsSocketTransportSession _transportSession;
     private final String _connectionId;
     // SYNC upon accessing any methods: itself.
     private final SessionAuthenticator _sessionAuthenticator;
 
     // :: Derived in constructor
-    private final Basic _webSocketBasicRemote;
     private final AuthenticationContextImpl _authenticationContext;
     private final ObjectReader _envelopeObjectReader;
     private final ObjectWriter _envelopeObjectWriter;
@@ -147,18 +144,17 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
     // SYNC upon adding when processing messages, and when reading from introspection: itself.
     private final List<MatsSocketEnvelopeWithMetaDto> _matsSocketEnvelopeWithMetaDtos = new ArrayList<>();
 
-    MatsSocketSessionAndMessageHandler(DefaultMatsSocketServer matsSocketServer, Session webSocketSession,
-            String connectionId, HandshakeRequest handshakeRequest, SessionAuthenticator sessionAuthenticator,
-            String remoteAddr) {
+    MatsSocketSessionAndMessageHandler(DefaultMatsSocketServer matsSocketServer,
+            MatsSocketTransportSession transportSession, String connectionId, HandshakeRequest handshakeRequest,
+            SessionAuthenticator sessionAuthenticator, String remoteAddr) {
         _matsSocketServer = matsSocketServer;
-        _webSocketSession = webSocketSession;
+        _transportSession = transportSession;
         _connectionId = connectionId;
         _sessionAuthenticator = sessionAuthenticator;
         // Might be resolved upon onOpen if we have a hack for doing it for this container.
         _remoteAddr = remoteAddr;
 
         // Derived
-        _webSocketBasicRemote = _webSocketSession.getBasicRemote();
         _authenticationContext = new AuthenticationContextImpl(handshakeRequest, this);
         _envelopeObjectReader = _matsSocketServer.getEnvelopeObjectReader();
         _envelopeObjectWriter = _matsSocketServer.getEnvelopeObjectWriter();
@@ -278,7 +274,7 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
 
     @Override
     public Session getWebSocketSession() {
-        return _webSocketSession;
+        return _transportSession.getJakartaSessionView();
     }
 
     @Override
@@ -328,7 +324,7 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
                         + " - probably async close, ignoring. Message:\n" + text);
                 return;
             }
-            _webSocketBasicRemote.sendText(text);
+            _transportSession.sendText(text);
         }
     }
 
@@ -355,9 +351,9 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
 
     boolean isWebSocketSessionOpen() {
         // Volatile, so read it out once
-        Session webSocketSession = _webSocketSession;
+        MatsSocketTransportSession transportSession = _transportSession;
         // .. then access it twice.
-        return webSocketSession != null && webSocketSession.isOpen();
+        return transportSession != null && transportSession.isOpen();
     }
 
     /**
@@ -419,8 +415,7 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
         _matsSocketServer.invokeMessageEventListeners(this, envelopes);
     }
 
-    @Override
-    public void onMessage(String message) {
+    void onMessage(String message) {
         // Record start of handling
         long receivedTimestamp = System.currentTimeMillis();
         long nanosStart = System.nanoTime();
@@ -1055,7 +1050,7 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
         closeSession(closeCode.getCode(), reason);
 
         // :: Close the actual WebSocket
-        DefaultMatsSocketServer.closeWebSocket(_webSocketSession, closeCode, reason);
+        DefaultMatsSocketServer.closeWebSocket(_transportSession.getJakartaSessionView(), closeCode, reason);
     }
 
     /**
@@ -1098,7 +1093,7 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
         deregisterSession(closeCode.getCode(), reason);
 
         // Close WebSocket
-        DefaultMatsSocketServer.closeWebSocket(_webSocketSession, closeCode, reason);
+        DefaultMatsSocketServer.closeWebSocket(_transportSession.getJakartaSessionView(), closeCode, reason);
     }
 
     private void commonDeregisterAndClose(MatsSocketSessionState state, Integer closeCode, String reason) {
@@ -1504,9 +1499,9 @@ class MatsSocketSessionAndMessageHandler implements Whole<String>, MatsSocketSta
         // ----- We're now a live MatsSocketSession!
 
         // Increase timeout to "prod timeout", now that client has said HELLO
-        _webSocketSession.setMaxIdleTimeout(75_000);
+        _transportSession.setMaxIdleTimeout(75_000);
         // Set high limit for text, as we don't want to be held back on the protocol side of things.
-        _webSocketSession.setMaxTextMessageBufferSize(50 * 1024 * 1024);
+        _transportSession.setMaxTextMessageBufferSize(50 * 1024 * 1024);
 
         // :: Record incoming Envelope
         recordEnvelopes(Collections.singletonList(envelope), clientMessageReceivedTimestamp, Direction.C2S);

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportHandler.java
@@ -1,0 +1,17 @@
+package io.mats3.matssocket.impl;
+
+/**
+ * Transport-facing session handler contract used by external transports (e.g. Quarkus) to avoid depending on
+ * implementation classes directly.
+ */
+public interface MatsSocketTransportHandler {
+    void onMessage(String message);
+
+    void setMDC();
+
+    String getMatsSocketSessionId();
+
+    void closeSession(Integer closeCode, String reason);
+
+    void deregisterSession(Integer closeCode, String reason);
+}

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportHandler.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportHandler.java
@@ -3,6 +3,8 @@ package io.mats3.matssocket.impl;
 /**
  * Transport-facing session handler contract used by external transports (e.g. Quarkus) to avoid depending on
  * implementation classes directly.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public interface MatsSocketTransportHandler {
     void onMessage(String message);

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportSession.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportSession.java
@@ -1,0 +1,46 @@
+package io.mats3.matssocket.impl;
+
+import java.io.IOException;
+
+import jakarta.websocket.Session;
+
+/**
+ * Internal transport session abstraction for MatsSocket. Decouples core session/message handling from the concrete
+ * WebSocket implementation (Jakarta WebSocket, Quarkus WebSockets Next, etc.).
+ * <p>
+ * Covers only runtime socket operations: send, close, connection state and buffer/timeout configuration. Does not
+ * abstract authentication or handshake - those remain at the transport edge.
+ *
+ * @author Thor Egil Kolltveit 2026-04-10 - thoregil@kolltveit.org
+ */
+interface MatsSocketTransportSession {
+
+    /** @return unique id for this WebSocket connection. */
+    String getId();
+
+    /** @return whether the underlying WebSocket connection is open. */
+    boolean isOpen();
+
+    /** Send a text message synchronously. */
+    void sendText(String text) throws IOException;
+
+    /** Close the connection with the given close code and reason phrase. */
+    void close(int closeCode, String reasonPhrase) throws IOException;
+
+    /** Set the idle timeout in milliseconds. Best-effort; some transports may not support per-connection timeouts. */
+    void setMaxIdleTimeout(long millis);
+
+    /** Set the max text message buffer size in bytes. Best-effort. */
+    void setMaxTextMessageBufferSize(int size);
+
+    /** Set the max binary message buffer size in bytes. Best-effort. */
+    void setMaxBinaryMessageBufferSize(int size);
+
+    /**
+     * @return a Jakarta WebSocket {@link Session} view of this transport session, for backwards compatibility with
+     *         {@link io.mats3.matssocket.MatsSocketServer.LiveMatsSocketSession#getWebSocketSession()
+     *         LiveMatsSocketSession.getWebSocketSession()}. Jakarta transport returns the real Session; Quarkus
+     *         transport returns a shim.
+     */
+    Session getJakartaSessionView();
+}

--- a/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportSession.java
+++ b/matssocket-server-impl/src/main/java/io/mats3/matssocket/impl/MatsSocketTransportSession.java
@@ -13,7 +13,7 @@ import jakarta.websocket.Session;
  *
  * @author Thor Egil Kolltveit 2026-04-10 - thoregil@kolltveit.org
  */
-interface MatsSocketTransportSession {
+public interface MatsSocketTransportSession {
 
     /** @return unique id for this WebSocket connection. */
     String getId();

--- a/matssocket-server-quarkus/build.gradle
+++ b/matssocket-server-quarkus/build.gradle
@@ -14,6 +14,13 @@ dependencies {
 
     // SLF4J for logging
     compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+
+    // :: TEST
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "jakarta.websocket:jakarta.websocket-api:$jakartaWebsocketsVersion"
+    testImplementation 'io.quarkus:quarkus-websockets-next:3.16.3'
+    testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 mavenPublishing {

--- a/matssocket-server-quarkus/build.gradle
+++ b/matssocket-server-quarkus/build.gradle
@@ -3,14 +3,14 @@
 // Auth shims are provided for the existing Jakarta-based AuthenticationPlugin API.
 
 dependencies {
-    // The MatsSocket server implementation (for MatsSocketTransportSession, DefaultMatsSocketServer, etc.)
-    api project(':matssocket-server-impl')
+    api project(':matssocket-server-api')
+    implementation project(':matssocket-server-impl')
 
     // Jakarta WebSocket API - needed for auth shims (HandshakeRequest, Session, ServerEndpointConfig)
     compileOnly "jakarta.websocket:jakarta.websocket-api:$jakartaWebsocketsVersion"
 
     // Quarkus WebSockets Next - what we're adapting from. compileOnly since consumers bring their own Quarkus.
-    compileOnly 'io.quarkus:quarkus-websockets-next:3.16.3'
+    compileOnly "io.quarkus:quarkus-websockets-next:$quarkusVersion"
 
     // SLF4J for logging
     compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
@@ -18,7 +18,7 @@ dependencies {
     // :: TEST
     testImplementation 'junit:junit:4.13.2'
     testImplementation "jakarta.websocket:jakarta.websocket-api:$jakartaWebsocketsVersion"
-    testImplementation 'io.quarkus:quarkus-websockets-next:3.16.3'
+    testImplementation "io.quarkus:quarkus-websockets-next:$quarkusVersion"
     testImplementation "org.slf4j:slf4j-api:$slf4jVersion"
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
 }

--- a/matssocket-server-quarkus/build.gradle
+++ b/matssocket-server-quarkus/build.gradle
@@ -2,19 +2,6 @@
 // Bridges Quarkus WebSockets Next into MatsSocket using the internal MatsSocketTransportSession abstraction.
 // Auth shims are provided for the existing Jakarta-based AuthenticationPlugin API.
 
-apply plugin: 'java-library'
-
-repositories { mavenCentral() }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
-}
-
-compileJava {
-    options.encoding = 'UTF-8'
-}
-
 dependencies {
     // The MatsSocket server implementation (for MatsSocketTransportSession, DefaultMatsSocketServer, etc.)
     api project(':matssocket-server-impl')
@@ -27,4 +14,12 @@ dependencies {
 
     // SLF4J for logging
     compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+}
+
+mavenPublishing {
+    pom {
+        name = 'MatsSocket Server Quarkus Adapter'
+        description = 'Adapter for running MatsSocket on Quarkus WebSockets Next, using a transport session' +
+                ' abstraction with Jakarta auth-edge shims for backwards compatibility.'
+    }
 }

--- a/matssocket-server-quarkus/build.gradle
+++ b/matssocket-server-quarkus/build.gradle
@@ -1,0 +1,30 @@
+// MatsSocket Server Quarkus Adapter
+// Bridges Quarkus WebSockets Next into MatsSocket using the internal MatsSocketTransportSession abstraction.
+// Auth shims are provided for the existing Jakarta-based AuthenticationPlugin API.
+
+apply plugin: 'java-library'
+
+repositories { mavenCentral() }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+compileJava {
+    options.encoding = 'UTF-8'
+}
+
+dependencies {
+    // The MatsSocket server implementation (for MatsSocketTransportSession, DefaultMatsSocketServer, etc.)
+    api project(':matssocket-server-impl')
+
+    // Jakarta WebSocket API - needed for auth shims (HandshakeRequest, Session, ServerEndpointConfig)
+    compileOnly "jakarta.websocket:jakarta.websocket-api:$jakartaWebsocketsVersion"
+
+    // Quarkus WebSockets Next - what we're adapting from. compileOnly since consumers bring their own Quarkus.
+    compileOnly 'io.quarkus:quarkus-websockets-next:3.16.3'
+
+    // SLF4J for logging
+    compileOnly "org.slf4j:slf4j-api:$slf4jVersion"
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
@@ -17,6 +17,8 @@ import io.mats3.matssocket.impl.DefaultMatsSocketServer;
  *         matsFactory, csaf, authPlugin, "/matssocket");
  * // Wire up your @WebSocket endpoint to delegate to setup.transport()
  * }</pre>
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class MatsSocketQuarkusFactory {
 
@@ -47,7 +49,11 @@ public class MatsSocketQuarkusFactory {
     }
 
     /**
-     * Setup result containing the MatsSocketServer and the Quarkus transport bridge.
+     * Result of creating a MatsSocket server with Quarkus transport.
+     *
+     * @param server the {@link MatsSocketServer} instance.
+     * @param transport the Quarkus transport bridge - wire this into your {@code @WebSocket} endpoint.
+     * @param websocketPath the WebSocket path this server is bound to.
      */
     public record MatsSocketQuarkusSetup(
             MatsSocketServer server,

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/MatsSocketQuarkusFactory.java
@@ -1,0 +1,57 @@
+package io.mats3.matssocket.quarkus;
+
+import io.mats3.MatsFactory;
+import io.mats3.matssocket.AuthenticationPlugin;
+import io.mats3.matssocket.ClusterStoreAndForward;
+import io.mats3.matssocket.MatsSocketServer;
+import io.mats3.matssocket.impl.DefaultMatsSocketServer;
+
+/**
+ * Factory for creating a {@link MatsSocketServer} with Quarkus WebSockets Next transport. Uses the internal
+ * {@link io.mats3.matssocket.impl.MatsSocketTransportSession} abstraction instead of faking a Jakarta
+ * {@code ServerContainer}/{@code Endpoint} lifecycle.
+ * <p>
+ * Usage:
+ * <pre>{@code
+ * MatsSocketQuarkusSetup setup = MatsSocketQuarkusFactory.create(
+ *         matsFactory, csaf, authPlugin, "/matssocket");
+ * // Wire up your @WebSocket endpoint to delegate to setup.transport()
+ * }</pre>
+ */
+public class MatsSocketQuarkusFactory {
+
+    /**
+     * Creates a MatsSocketServer with Quarkus transport.
+     *
+     * @return a {@link MatsSocketQuarkusSetup} containing the server and transport bridge.
+     */
+    public static MatsSocketQuarkusSetup create(MatsFactory matsFactory, ClusterStoreAndForward csaf,
+            AuthenticationPlugin authPlugin, String websocketPath) {
+        return create(matsFactory, csaf, authPlugin,
+                matsFactory.getFactoryConfig().getAppName(), websocketPath);
+    }
+
+    /**
+     * Creates a MatsSocketServer with Quarkus transport and explicit instance name.
+     */
+    public static MatsSocketQuarkusSetup create(MatsFactory matsFactory, ClusterStoreAndForward csaf,
+            AuthenticationPlugin authPlugin, String instanceName, String websocketPath) {
+        // Create MatsSocketServer without Jakarta endpoint registration
+        DefaultMatsSocketServer server = DefaultMatsSocketServer.createForExternalTransport(
+                matsFactory, csaf, authPlugin, instanceName);
+
+        // Create the Quarkus transport bridge
+        QuarkusMatsSocketTransport transport = new QuarkusMatsSocketTransport(server, authPlugin, websocketPath);
+
+        return new MatsSocketQuarkusSetup(server, transport, websocketPath);
+    }
+
+    /**
+     * Setup result containing the MatsSocketServer and the Quarkus transport bridge.
+     */
+    public record MatsSocketQuarkusSetup(
+            MatsSocketServer server,
+            QuarkusMatsSocketTransport transport,
+            String websocketPath) {
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
@@ -14,6 +14,8 @@ import jakarta.websocket.server.HandshakeRequest;
  * Jakarta {@link HandshakeRequest} auth-edge shim wrapping Quarkus WebSockets Next handshake info. Exists because
  * {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator#checkHandshake} and
  * {@link io.mats3.matssocket.AuthenticationPlugin.AuthenticationContext#getHandshakeRequest} expect Jakarta types.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class QuarkusHandshakeRequest implements HandshakeRequest {
 

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
@@ -1,0 +1,108 @@
+package io.mats3.matssocket.quarkus;
+
+import java.net.URI;
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.websocket.server.HandshakeRequest;
+
+/**
+ * Jakarta {@link HandshakeRequest} auth-edge shim wrapping Quarkus WebSockets Next handshake info. Exists because
+ * {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator#checkHandshake} and
+ * {@link io.mats3.matssocket.AuthenticationPlugin.AuthenticationContext#getHandshakeRequest} expect Jakarta types.
+ */
+public class QuarkusHandshakeRequest implements HandshakeRequest {
+
+    private final Map<String, List<String>> _headers;
+    private final Map<String, List<String>> _parameterMap;
+    private final URI _requestUri;
+    private final String _queryString;
+
+    public QuarkusHandshakeRequest(io.quarkus.websockets.next.HandshakeRequest quarkusHandshake) {
+        _headers = quarkusHandshake != null ? new HashMap<>(quarkusHandshake.headers()) : new HashMap<>();
+        _parameterMap = new HashMap<>();
+        _queryString = quarkusHandshake != null ? quarkusHandshake.query() : null;
+
+        if (_queryString != null && !_queryString.isEmpty()) {
+            for (String pair : _queryString.split("&")) {
+                int idx = pair.indexOf('=');
+                String key = idx > 0 ? urlDecode(pair.substring(0, idx)) : urlDecode(pair);
+                String value = idx > 0 && pair.length() > idx + 1 ? urlDecode(pair.substring(idx + 1)) : "";
+                _parameterMap.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+            }
+        }
+
+        if (quarkusHandshake != null) {
+            try {
+                String scheme = quarkusHandshake.scheme();
+                String host = quarkusHandshake.host();
+                int port = quarkusHandshake.port();
+                String path = quarkusHandshake.path();
+                String authority = host;
+                if ((scheme.equals("ws") || scheme.equals("http")) && port != 80 && port > 0) {
+                    authority = host + ":" + port;
+                }
+                else if ((scheme.equals("wss") || scheme.equals("https")) && port != 443 && port > 0) {
+                    authority = host + ":" + port;
+                }
+                String fullPath = _queryString != null && !_queryString.isEmpty()
+                        ? path + "?" + _queryString : path;
+                _requestUri = new URI(scheme + "://" + authority + fullPath);
+            }
+            catch (Exception e) {
+                throw new RuntimeException("Failed to construct request URI", e);
+            }
+        }
+        else {
+            _requestUri = null;
+        }
+    }
+
+    private static String urlDecode(String value) {
+        try {
+            return java.net.URLDecoder.decode(value, "UTF-8");
+        }
+        catch (Exception e) {
+            return value;
+        }
+    }
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return Collections.unmodifiableMap(_headers);
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null; // MatsSocket handles authentication separately.
+    }
+
+    @Override
+    public URI getRequestURI() {
+        return _requestUri;
+    }
+
+    @Override
+    public boolean isUserInRole(String role) {
+        return false;
+    }
+
+    @Override
+    public Object getHttpSession() {
+        return null;
+    }
+
+    @Override
+    public Map<String, List<String>> getParameterMap() {
+        return Collections.unmodifiableMap(_parameterMap);
+    }
+
+    @Override
+    public String getQueryString() {
+        return _queryString;
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeRequest.java
@@ -17,14 +17,14 @@ import jakarta.websocket.server.HandshakeRequest;
  *
  * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
-public class QuarkusHandshakeRequest implements HandshakeRequest {
+class QuarkusHandshakeRequest implements HandshakeRequest {
 
     private final Map<String, List<String>> _headers;
     private final Map<String, List<String>> _parameterMap;
     private final URI _requestUri;
     private final String _queryString;
 
-    public QuarkusHandshakeRequest(io.quarkus.websockets.next.HandshakeRequest quarkusHandshake) {
+    QuarkusHandshakeRequest(io.quarkus.websockets.next.HandshakeRequest quarkusHandshake) {
         _headers = quarkusHandshake != null ? new HashMap<>(quarkusHandshake.headers()) : new HashMap<>();
         _parameterMap = new HashMap<>();
         _queryString = quarkusHandshake != null ? quarkusHandshake.query() : null;
@@ -44,16 +44,10 @@ public class QuarkusHandshakeRequest implements HandshakeRequest {
                 String host = quarkusHandshake.host();
                 int port = quarkusHandshake.port();
                 String path = quarkusHandshake.path();
-                String authority = host;
-                if ((scheme.equals("ws") || scheme.equals("http")) && port != 80 && port > 0) {
-                    authority = host + ":" + port;
-                }
-                else if ((scheme.equals("wss") || scheme.equals("https")) && port != 443 && port > 0) {
-                    authority = host + ":" + port;
-                }
-                String fullPath = _queryString != null && !_queryString.isEmpty()
-                        ? path + "?" + _queryString : path;
-                _requestUri = new URI(scheme + "://" + authority + fullPath);
+                int uriPort = isDefaultPort(scheme, port) ? -1 : port;
+                URI baseUri = new URI(scheme, null, host, uriPort, path, null, null);
+                _requestUri = _queryString != null && !_queryString.isEmpty()
+                        ? new URI(baseUri.toASCIIString() + "?" + _queryString) : baseUri;
             }
             catch (Exception e) {
                 throw new RuntimeException("Failed to construct request URI", e);
@@ -71,6 +65,12 @@ public class QuarkusHandshakeRequest implements HandshakeRequest {
         catch (Exception e) {
             return value;
         }
+    }
+
+    private static boolean isDefaultPort(String scheme, int port) {
+        return port <= 0
+                || (("ws".equals(scheme) || "http".equals(scheme)) && port == 80)
+                || (("wss".equals(scheme) || "https".equals(scheme)) && port == 443);
     }
 
     @Override

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
@@ -13,6 +13,8 @@ import jakarta.websocket.HandshakeResponse;
  * Jakarta {@link HandshakeResponse} auth-edge shim. <b>Lossy:</b> Quarkus WebSockets Next cannot mutate HTTP response
  * headers after the WebSocket upgrade. If an {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator}
  * sets headers during {@code checkHandshake(...)}, a warning is logged since those headers will not be delivered.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class QuarkusHandshakeResponse implements HandshakeResponse {
     private static final Logger log = LoggerFactory.getLogger(QuarkusHandshakeResponse.class);

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
@@ -16,7 +16,7 @@ import jakarta.websocket.HandshakeResponse;
  *
  * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
-public class QuarkusHandshakeResponse implements HandshakeResponse {
+class QuarkusHandshakeResponse implements HandshakeResponse {
     private static final Logger log = LoggerFactory.getLogger(QuarkusHandshakeResponse.class);
 
     private final Map<String, List<String>> _headers = new HashMap<>();

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusHandshakeResponse.java
@@ -1,0 +1,36 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.websocket.HandshakeResponse;
+
+/**
+ * Jakarta {@link HandshakeResponse} auth-edge shim. <b>Lossy:</b> Quarkus WebSockets Next cannot mutate HTTP response
+ * headers after the WebSocket upgrade. If an {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator}
+ * sets headers during {@code checkHandshake(...)}, a warning is logged since those headers will not be delivered.
+ */
+public class QuarkusHandshakeResponse implements HandshakeResponse {
+    private static final Logger log = LoggerFactory.getLogger(QuarkusHandshakeResponse.class);
+
+    private final Map<String, List<String>> _headers = new HashMap<>();
+
+    @Override
+    public Map<String, List<String>> getHeaders() {
+        return _headers;
+    }
+
+    /**
+     * Called after {@code checkHandshake(...)} to warn if the auth plugin set response headers that cannot be delivered.
+     */
+    public void warnIfHeadersWereSet() {
+        if (!_headers.isEmpty()) {
+            log.warn("Auth plugin set response headers during checkHandshake(), but Quarkus WebSockets Next cannot"
+                    + " send response headers after upgrade. Headers lost: " + _headers.keySet());
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketTransport.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketTransport.java
@@ -1,0 +1,211 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mats3.matssocket.AuthenticationPlugin;
+import io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator;
+import io.mats3.matssocket.MatsSocketServer.MatsSocketCloseCodes;
+import io.mats3.matssocket.impl.DefaultMatsSocketServer;
+import io.mats3.matssocket.impl.MatsSocketTransportHandler;
+import io.quarkus.websockets.next.WebSocketConnection;
+
+/**
+ * Bridges Quarkus WebSockets Next events into MatsSocket without pretending to be a Jakarta ServerContainer or
+ * Endpoint lifecycle. The application's {@code @WebSocket} endpoint delegates its {@code @OnOpen}, {@code @OnTextMessage},
+ * {@code @OnClose} and {@code @OnError} callbacks to this class.
+ * <p>
+ * Auth shims are created for each connection to satisfy the Jakarta-typed
+ * {@link io.mats3.matssocket.AuthenticationPlugin} API.
+ */
+public class QuarkusMatsSocketTransport {
+    private static final Logger log = LoggerFactory.getLogger(QuarkusMatsSocketTransport.class);
+
+    private final DefaultMatsSocketServer _matsSocketServer;
+    private final AuthenticationPlugin _authenticationPlugin;
+    private final String _websocketPath;
+
+    // Per-connection state: connectionId -> SessionData
+    private final Map<String, SessionData> _sessions = new ConcurrentHashMap<>();
+
+    QuarkusMatsSocketTransport(DefaultMatsSocketServer matsSocketServer, AuthenticationPlugin authenticationPlugin,
+            String websocketPath) {
+        _matsSocketServer = matsSocketServer;
+        _authenticationPlugin = authenticationPlugin;
+        _websocketPath = websocketPath;
+    }
+
+    /**
+     * Called from the application's {@code @OnOpen} handler.
+     */
+    public void onOpen(WebSocketConnection connection,
+            io.quarkus.websockets.next.HandshakeRequest quarkusHandshake) {
+        String connectionId = connection.id() + "_Q";
+
+        // :: Create auth shims
+        QuarkusHandshakeRequest handshakeRequest = new QuarkusHandshakeRequest(quarkusHandshake);
+        QuarkusHandshakeResponse handshakeResponse = new QuarkusHandshakeResponse();
+        QuarkusServerEndpointConfigShim serverEndpointConfig = new QuarkusServerEndpointConfigShim(_websocketPath);
+
+        // :: Create transport session + session shim (backed by same transport)
+        QuarkusTransportSession transportSession = new QuarkusTransportSession(connection, handshakeRequest);
+
+        // ?: If we are going down, then immediately close it.
+        if (_matsSocketServer.isStopped()) {
+            DefaultMatsSocketServer.closeTransportSession(transportSession,
+                    MatsSocketCloseCodes.SERVICE_RESTART.getCode(),
+                    "This server is going down, perform a (re)connect to another instance.");
+            return;
+        }
+
+        // :: Set low pre-HELLO limits before auth
+        _matsSocketServer.configurePreAuthSession(transportSession);
+
+        // :: Create SessionAuthenticator
+        SessionAuthenticator sessionAuthenticator = _authenticationPlugin.newSessionAuthenticator();
+
+        // :: Run auth flow - same methods as Jakarta, just invoked sequentially after accept
+
+        // 1. checkOrigin
+        String origin = getOriginHeader(handshakeRequest);
+        boolean originOk = sessionAuthenticator.checkOrigin(origin);
+        log.info("checkOrigin(" + origin + "). SessionAuthenticator returned: " + (originOk ? "OK" : "NOT OK!"));
+        if (!originOk) {
+            DefaultMatsSocketServer.closeTransportSession(transportSession,
+                    MatsSocketCloseCodes.VIOLATED_POLICY.getCode(), "Origin check failed");
+            return;
+        }
+
+        // 2. checkHandshake
+        boolean handshakeOk = sessionAuthenticator.checkHandshake(serverEndpointConfig, handshakeRequest,
+                handshakeResponse);
+        log.info("checkHandshake(). SessionAuthenticator returned: " + (handshakeOk ? "OK" : "NOT OK!"));
+        handshakeResponse.warnIfHeadersWereSet();
+        if (!handshakeOk) {
+            DefaultMatsSocketServer.closeTransportSession(transportSession,
+                    MatsSocketCloseCodes.VIOLATED_POLICY.getCode(), "Handshake check failed");
+            return;
+        }
+
+        // 3. onOpen
+        try {
+            boolean openOk = sessionAuthenticator.onOpen(transportSession.getJakartaSessionView(),
+                    serverEndpointConfig);
+            log.info("onOpen(). SessionAuthenticator returned: " + (openOk ? "OK" : "NOT OK!"));
+            if (!openOk) {
+                DefaultMatsSocketServer.closeTransportSession(transportSession,
+                        MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                        "SessionAuthenticator did not want this session to proceed");
+                return;
+            }
+        }
+        catch (Throwable t) {
+            log.error("Got throwable when invoking SessionAuthenticator.onOpen(). Closing.", t);
+            DefaultMatsSocketServer.closeTransportSession(transportSession,
+                    MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
+                    "SessionAuthenticator did not want this session to proceed");
+            return;
+        }
+
+        // :: Resolve remote address (best-effort from headers)
+        String remoteAddr = resolveRemoteAddr(handshakeRequest);
+
+        // :: Create MatsSocket session handler
+        MatsSocketTransportHandler handler = _matsSocketServer.createSessionHandlerAfterAuth(
+                transportSession, connectionId, handshakeRequest, sessionAuthenticator, remoteAddr);
+
+        _sessions.put(connection.id(), new SessionData(transportSession, handler, connectionId));
+
+        log.info("MatsSocket connection established: connectionId=" + connectionId);
+    }
+
+    /**
+     * Called from the application's {@code @OnTextMessage} handler.
+     */
+    public void onMessage(WebSocketConnection connection, String message) {
+        SessionData sessionData = _sessions.get(connection.id());
+        if (sessionData != null) {
+            sessionData._handler.onMessage(message);
+        }
+        else {
+            log.warn("Received message for unknown connection: " + connection.id());
+        }
+    }
+
+    /**
+     * Called from the application's {@code @OnClose} handler.
+     */
+    public void onClose(WebSocketConnection connection, io.quarkus.websockets.next.CloseReason closeReason) {
+        SessionData sessionData = _sessions.remove(connection.id());
+        if (sessionData != null) {
+            int code = closeReason != null ? closeReason.getCode() : 1000;
+            String reason = closeReason != null ? closeReason.getMessage() : "Connection closed";
+            DefaultMatsSocketServer.handleTransportClose(sessionData._handler, sessionData._transportSession,
+                    sessionData._connectionId, code, reason, sessionData._isTimeoutException);
+        }
+    }
+
+    /**
+     * Called from the application's {@code @OnError} handler.
+     */
+    public void onError(WebSocketConnection connection, Throwable thr) {
+        SessionData sessionData = _sessions.get(connection.id());
+        if (sessionData != null) {
+            sessionData._isTimeoutException = DefaultMatsSocketServer.handleTransportError(
+                    sessionData._handler, sessionData._transportSession, thr);
+        }
+        else {
+            log.warn("Error on unknown/pre-auth connection: " + connection.id(), thr);
+        }
+    }
+
+    public int getActiveConnectionCount() {
+        return _sessions.size();
+    }
+
+    // ---- Internals ----
+
+    private static String getOriginHeader(QuarkusHandshakeRequest handshakeRequest) {
+        List<String> origins = getHeaderValuesIgnoreCase(handshakeRequest.getHeaders(), "Origin");
+        return (origins != null && !origins.isEmpty()) ? origins.get(0) : null;
+    }
+
+    private static String resolveRemoteAddr(QuarkusHandshakeRequest handshakeRequest) {
+        // Try X-Forwarded-For first (common in proxied setups)
+        List<String> xff = getHeaderValuesIgnoreCase(handshakeRequest.getHeaders(), "X-Forwarded-For");
+        if (xff != null && !xff.isEmpty()) {
+            // Take the first (leftmost) IP
+            String first = xff.get(0);
+            int comma = first.indexOf(',');
+            return comma > 0 ? first.substring(0, comma).trim() : first.trim();
+        }
+        return null; // Quarkus WebSockets Next doesn't expose remote address directly.
+    }
+
+    private static List<String> getHeaderValuesIgnoreCase(Map<String, List<String>> headers, String headerName) {
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(headerName)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static class SessionData {
+        final QuarkusTransportSession _transportSession;
+        final MatsSocketTransportHandler _handler;
+        final String _connectionId;
+        volatile boolean _isTimeoutException;
+
+        SessionData(QuarkusTransportSession transportSession, MatsSocketTransportHandler handler,
+                String connectionId) {
+            _transportSession = transportSession;
+            _handler = handler;
+            _connectionId = connectionId;
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketTransport.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusMatsSocketTransport.java
@@ -21,6 +21,8 @@ import io.quarkus.websockets.next.WebSocketConnection;
  * <p>
  * Auth shims are created for each connection to satisfy the Jakarta-typed
  * {@link io.mats3.matssocket.AuthenticationPlugin} API.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class QuarkusMatsSocketTransport {
     private static final Logger log = LoggerFactory.getLogger(QuarkusMatsSocketTransport.class);
@@ -73,7 +75,7 @@ public class QuarkusMatsSocketTransport {
         // 1. checkOrigin
         String origin = getOriginHeader(handshakeRequest);
         boolean originOk = sessionAuthenticator.checkOrigin(origin);
-        log.info("checkOrigin(" + origin + "). SessionAuthenticator returned: " + (originOk ? "OK" : "NOT OK!"));
+        log.info("checkOrigin({}). SessionAuthenticator returned: {}", origin, originOk ? "OK" : "NOT OK!");
         if (!originOk) {
             DefaultMatsSocketServer.closeTransportSession(transportSession,
                     MatsSocketCloseCodes.VIOLATED_POLICY.getCode(), "Origin check failed");
@@ -83,7 +85,7 @@ public class QuarkusMatsSocketTransport {
         // 2. checkHandshake
         boolean handshakeOk = sessionAuthenticator.checkHandshake(serverEndpointConfig, handshakeRequest,
                 handshakeResponse);
-        log.info("checkHandshake(). SessionAuthenticator returned: " + (handshakeOk ? "OK" : "NOT OK!"));
+        log.info("checkHandshake(). SessionAuthenticator returned: {}", handshakeOk ? "OK" : "NOT OK!");
         handshakeResponse.warnIfHeadersWereSet();
         if (!handshakeOk) {
             DefaultMatsSocketServer.closeTransportSession(transportSession,
@@ -95,7 +97,7 @@ public class QuarkusMatsSocketTransport {
         try {
             boolean openOk = sessionAuthenticator.onOpen(transportSession.getJakartaSessionView(),
                     serverEndpointConfig);
-            log.info("onOpen(). SessionAuthenticator returned: " + (openOk ? "OK" : "NOT OK!"));
+            log.info("onOpen(). SessionAuthenticator returned: {}", openOk ? "OK" : "NOT OK!");
             if (!openOk) {
                 DefaultMatsSocketServer.closeTransportSession(transportSession,
                         MatsSocketCloseCodes.VIOLATED_POLICY.getCode(),
@@ -120,7 +122,7 @@ public class QuarkusMatsSocketTransport {
 
         _sessions.put(connection.id(), new SessionData(transportSession, handler, connectionId));
 
-        log.info("MatsSocket connection established: connectionId=" + connectionId);
+        log.info("MatsSocket connection established: connectionId={}", connectionId);
     }
 
     /**
@@ -143,7 +145,8 @@ public class QuarkusMatsSocketTransport {
         SessionData sessionData = _sessions.remove(connection.id());
         if (sessionData != null) {
             int code = closeReason != null ? closeReason.getCode() : 1000;
-            String reason = closeReason != null ? closeReason.getMessage() : "Connection closed";
+            String message = closeReason != null ? closeReason.getMessage() : null;
+            String reason = message != null ? message : "Connection closed";
             DefaultMatsSocketServer.handleTransportClose(sessionData._handler, sessionData._transportSession,
                     sessionData._connectionId, code, reason, sessionData._isTimeoutException);
         }
@@ -167,7 +170,7 @@ public class QuarkusMatsSocketTransport {
         return _sessions.size();
     }
 
-    // ---- Internals ----
+    // :: Internals
 
     private static String getOriginHeader(QuarkusHandshakeRequest handshakeRequest) {
         List<String> origins = getHeaderValuesIgnoreCase(handshakeRequest.getHeaders(), "Origin");

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
@@ -16,7 +16,7 @@ import jakarta.websocket.server.ServerEndpointConfig;
  *
  * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
-public class QuarkusServerEndpointConfigShim implements ServerEndpointConfig {
+class QuarkusServerEndpointConfigShim implements ServerEndpointConfig {
 
     private final String _path;
     private final Map<String, Object> _userProperties = new ConcurrentHashMap<>();

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
@@ -13,6 +13,8 @@ import jakarta.websocket.server.ServerEndpointConfig;
 /**
  * Jakarta {@link ServerEndpointConfig} auth-edge shim for Quarkus. Provides path, subprotocols and user properties
  * to {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator#checkHandshake} and {@code onOpen}.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class QuarkusServerEndpointConfigShim implements ServerEndpointConfig {
 

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusServerEndpointConfigShim.java
@@ -1,0 +1,65 @@
+package io.mats3.matssocket.quarkus;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.websocket.Decoder;
+import jakarta.websocket.Encoder;
+import jakarta.websocket.Extension;
+import jakarta.websocket.server.ServerEndpointConfig;
+
+/**
+ * Jakarta {@link ServerEndpointConfig} auth-edge shim for Quarkus. Provides path, subprotocols and user properties
+ * to {@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator#checkHandshake} and {@code onOpen}.
+ */
+public class QuarkusServerEndpointConfigShim implements ServerEndpointConfig {
+
+    private final String _path;
+    private final Map<String, Object> _userProperties = new ConcurrentHashMap<>();
+
+    QuarkusServerEndpointConfigShim(String path) {
+        _path = path;
+    }
+
+    @Override
+    public String getPath() {
+        return _path;
+    }
+
+    @Override
+    public List<String> getSubprotocols() {
+        return Collections.singletonList("matssocket");
+    }
+
+    @Override
+    public Map<String, Object> getUserProperties() {
+        return _userProperties;
+    }
+
+    @Override
+    public Class<?> getEndpointClass() {
+        return Void.class; // Not meaningful for Quarkus transport.
+    }
+
+    @Override
+    public List<Class<? extends Encoder>> getEncoders() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Class<? extends Decoder>> getDecoders() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Extension> getExtensions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Configurator getConfigurator() {
+        return null;
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusSessionShim.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusSessionShim.java
@@ -11,13 +11,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
 
 import jakarta.websocket.CloseReason;
 import jakarta.websocket.Extension;
 import jakarta.websocket.MessageHandler;
 import jakarta.websocket.RemoteEndpoint;
-import jakarta.websocket.SendHandler;
 import jakarta.websocket.Session;
 import jakarta.websocket.WebSocketContainer;
 
@@ -29,6 +27,8 @@ import jakarta.websocket.WebSocketContainer;
  *     <li>{@link io.mats3.matssocket.MatsSocketServer.LiveMatsSocketSession#getWebSocketSession()}</li>
  * </ul>
  * Implements harmless getters/setters. Unsupported operations throw {@link UnsupportedOperationException}.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 class QuarkusSessionShim implements Session {
 
@@ -88,7 +88,7 @@ class QuarkusSessionShim implements Session {
         return _basicRemote;
     }
 
-    // -- Timeout/buffer setters delegating to transport session --
+    // :: Timeout/buffer setters delegating to transport session
 
     @Override
     public long getMaxIdleTimeout() {
@@ -192,7 +192,7 @@ class QuarkusSessionShim implements Session {
         throw new UnsupportedOperationException("getAsyncRemote() not supported in Quarkus transport shim");
     }
 
-    // ---- Minimal BasicRemote shim, backed by QuarkusTransportSession.sendText(...) ----
+    // :: Minimal BasicRemote shim, backed by QuarkusTransportSession.sendText(...)
 
     private static class BasicRemoteShim implements RemoteEndpoint.Basic {
         private final QuarkusTransportSession _transport;

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusSessionShim.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusSessionShim.java
@@ -1,0 +1,264 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+import jakarta.websocket.CloseReason;
+import jakarta.websocket.Extension;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.SendHandler;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
+
+/**
+ * Jakarta {@link Session} auth-edge shim backed by a {@link QuarkusTransportSession}. Used for:
+ * <ul>
+ *     <li>{@link io.mats3.matssocket.AuthenticationPlugin.SessionAuthenticator#onOpen(Session,
+ *     jakarta.websocket.server.ServerEndpointConfig)}</li>
+ *     <li>{@link io.mats3.matssocket.MatsSocketServer.LiveMatsSocketSession#getWebSocketSession()}</li>
+ * </ul>
+ * Implements harmless getters/setters. Unsupported operations throw {@link UnsupportedOperationException}.
+ */
+class QuarkusSessionShim implements Session {
+
+    private final QuarkusTransportSession _transportSession;
+    private final QuarkusHandshakeRequest _handshakeRequest;
+    private final Map<String, Object> _userProperties = new ConcurrentHashMap<>();
+    private final RemoteEndpoint.Basic _basicRemote;
+
+    QuarkusSessionShim(QuarkusTransportSession transportSession, QuarkusHandshakeRequest handshakeRequest) {
+        _transportSession = transportSession;
+        _handshakeRequest = handshakeRequest;
+        _basicRemote = new BasicRemoteShim(transportSession);
+    }
+
+    @Override
+    public String getId() {
+        return _transportSession.getId();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return _transportSession.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        _transportSession.close(1000, "Normal closure");
+    }
+
+    @Override
+    public void close(CloseReason closeReason) throws IOException {
+        _transportSession.close(closeReason.getCloseCode().getCode(), closeReason.getReasonPhrase());
+    }
+
+    @Override
+    public Map<String, Object> getUserProperties() {
+        return _userProperties;
+    }
+
+    @Override
+    public URI getRequestURI() {
+        return _handshakeRequest.getRequestURI();
+    }
+
+    @Override
+    public Map<String, List<String>> getRequestParameterMap() {
+        return _handshakeRequest.getParameterMap();
+    }
+
+    @Override
+    public String getQueryString() {
+        return _handshakeRequest.getQueryString();
+    }
+
+    @Override
+    public RemoteEndpoint.Basic getBasicRemote() {
+        return _basicRemote;
+    }
+
+    // -- Timeout/buffer setters delegating to transport session --
+
+    @Override
+    public long getMaxIdleTimeout() {
+        return _transportSession.getMaxIdleTimeout();
+    }
+
+    @Override
+    public void setMaxIdleTimeout(long milliseconds) {
+        _transportSession.setMaxIdleTimeout(milliseconds);
+    }
+
+    @Override
+    public int getMaxTextMessageBufferSize() {
+        return _transportSession.getMaxTextMessageBufferSize();
+    }
+
+    @Override
+    public void setMaxTextMessageBufferSize(int length) {
+        _transportSession.setMaxTextMessageBufferSize(length);
+    }
+
+    @Override
+    public int getMaxBinaryMessageBufferSize() {
+        return _transportSession.getMaxBinaryMessageBufferSize();
+    }
+
+    @Override
+    public void setMaxBinaryMessageBufferSize(int length) {
+        _transportSession.setMaxBinaryMessageBufferSize(length);
+    }
+
+    @Override
+    public String getProtocolVersion() {
+        return "13";
+    }
+
+    @Override
+    public String getNegotiatedSubprotocol() {
+        return "matssocket";
+    }
+
+    @Override
+    public List<Extension> getNegotiatedExtensions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isSecure() {
+        URI uri = getRequestURI();
+        return uri != null && ("wss".equals(uri.getScheme()) || "https".equals(uri.getScheme()));
+    }
+
+    @Override
+    public WebSocketContainer getContainer() {
+        return null;
+    }
+
+    @Override
+    public Principal getUserPrincipal() {
+        return null; // MatsSocket handles auth separately.
+    }
+
+    @Override
+    public Map<String, String> getPathParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public Set<Session> getOpenSessions() {
+        throw new UnsupportedOperationException("getOpenSessions() not supported in Quarkus transport shim");
+    }
+
+    @Override
+    public void addMessageHandler(MessageHandler handler) {
+        throw new UnsupportedOperationException("addMessageHandler() not supported in Quarkus transport shim"
+                + " - message routing is handled by QuarkusMatsSocketTransport");
+    }
+
+    @Override
+    public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Whole<T> handler) {
+        throw new UnsupportedOperationException("addMessageHandler() not supported in Quarkus transport shim");
+    }
+
+    @Override
+    public <T> void addMessageHandler(Class<T> clazz, MessageHandler.Partial<T> handler) {
+        throw new UnsupportedOperationException("addMessageHandler() not supported in Quarkus transport shim");
+    }
+
+    @Override
+    public Set<MessageHandler> getMessageHandlers() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public void removeMessageHandler(MessageHandler handler) {
+        // No-op.
+    }
+
+    @Override
+    public RemoteEndpoint.Async getAsyncRemote() {
+        throw new UnsupportedOperationException("getAsyncRemote() not supported in Quarkus transport shim");
+    }
+
+    // ---- Minimal BasicRemote shim, backed by QuarkusTransportSession.sendText(...) ----
+
+    private static class BasicRemoteShim implements RemoteEndpoint.Basic {
+        private final QuarkusTransportSession _transport;
+
+        BasicRemoteShim(QuarkusTransportSession transport) {
+            _transport = transport;
+        }
+
+        @Override
+        public void sendText(String text) throws IOException {
+            _transport.sendText(text);
+        }
+
+        @Override
+        public void sendBinary(ByteBuffer data) throws IOException {
+            throw new UnsupportedOperationException("sendBinary() not supported in Quarkus transport shim");
+        }
+
+        @Override
+        public void sendText(String partialMessage, boolean isLast) throws IOException {
+            throw new UnsupportedOperationException("Partial sendText() not supported");
+        }
+
+        @Override
+        public void sendBinary(ByteBuffer partialByte, boolean isLast) throws IOException {
+            throw new UnsupportedOperationException("Partial sendBinary() not supported");
+        }
+
+        @Override
+        public OutputStream getSendStream() {
+            throw new UnsupportedOperationException("getSendStream() not supported");
+        }
+
+        @Override
+        public Writer getSendWriter() {
+            throw new UnsupportedOperationException("getSendWriter() not supported");
+        }
+
+        @Override
+        public void sendObject(Object data) throws IOException {
+            throw new UnsupportedOperationException("sendObject() not supported");
+        }
+
+        @Override
+        public void setBatchingAllowed(boolean allowed) {
+            // No-op.
+        }
+
+        @Override
+        public boolean getBatchingAllowed() {
+            return false;
+        }
+
+        @Override
+        public void flushBatch() {
+            // No-op.
+        }
+
+        @Override
+        public void sendPing(ByteBuffer applicationData) {
+            // No-op, Quarkus handles ping/pong automatically.
+        }
+
+        @Override
+        public void sendPong(ByteBuffer applicationData) {
+            // No-op.
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
@@ -10,6 +10,8 @@ import io.quarkus.websockets.next.WebSocketConnection;
 /**
  * Quarkus WebSockets Next implementation of {@link MatsSocketTransportSession}. Wraps a {@link WebSocketConnection}
  * for use by MatsSocket core's session/message handling.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
 public class QuarkusTransportSession implements MatsSocketTransportSession {
 

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
@@ -13,7 +13,7 @@ import io.quarkus.websockets.next.WebSocketConnection;
  *
  * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
  */
-public class QuarkusTransportSession implements MatsSocketTransportSession {
+class QuarkusTransportSession implements MatsSocketTransportSession {
 
     private final WebSocketConnection _connection;
     private final QuarkusSessionShim _sessionShim;

--- a/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
+++ b/matssocket-server-quarkus/src/main/java/io/mats3/matssocket/quarkus/QuarkusTransportSession.java
@@ -1,0 +1,80 @@
+package io.mats3.matssocket.quarkus;
+
+import java.io.IOException;
+
+import jakarta.websocket.Session;
+
+import io.mats3.matssocket.impl.MatsSocketTransportSession;
+import io.quarkus.websockets.next.WebSocketConnection;
+
+/**
+ * Quarkus WebSockets Next implementation of {@link MatsSocketTransportSession}. Wraps a {@link WebSocketConnection}
+ * for use by MatsSocket core's session/message handling.
+ */
+public class QuarkusTransportSession implements MatsSocketTransportSession {
+
+    private final WebSocketConnection _connection;
+    private final QuarkusSessionShim _sessionShim;
+
+    // Stored locally since Quarkus may not support per-connection configuration.
+    private long _maxIdleTimeout;
+    private int _maxTextMessageBufferSize;
+    private int _maxBinaryMessageBufferSize;
+
+    QuarkusTransportSession(WebSocketConnection connection, QuarkusHandshakeRequest handshakeRequest) {
+        _connection = connection;
+        _sessionShim = new QuarkusSessionShim(this, handshakeRequest);
+    }
+
+    @Override
+    public String getId() {
+        return _connection.id();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !_connection.isClosed();
+    }
+
+    @Override
+    public void sendText(String text) throws IOException {
+        _connection.sendTextAndAwait(text);
+    }
+
+    @Override
+    public void close(int closeCode, String reasonPhrase) throws IOException {
+        _connection.closeAndAwait(new io.quarkus.websockets.next.CloseReason(closeCode, reasonPhrase));
+    }
+
+    @Override
+    public void setMaxIdleTimeout(long millis) {
+        _maxIdleTimeout = millis;
+    }
+
+    @Override
+    public void setMaxTextMessageBufferSize(int size) {
+        _maxTextMessageBufferSize = size;
+    }
+
+    @Override
+    public void setMaxBinaryMessageBufferSize(int size) {
+        _maxBinaryMessageBufferSize = size;
+    }
+
+    @Override
+    public Session getJakartaSessionView() {
+        return _sessionShim;
+    }
+
+    long getMaxIdleTimeout() {
+        return _maxIdleTimeout;
+    }
+
+    int getMaxTextMessageBufferSize() {
+        return _maxTextMessageBufferSize;
+    }
+
+    int getMaxBinaryMessageBufferSize() {
+        return _maxBinaryMessageBufferSize;
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
@@ -78,6 +78,21 @@ public class Test_QuarkusHandshakeRequest {
     }
 
     @Test
+    public void requestUri_encodedQuery_shouldNotDoubleEncode() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._scheme = "wss";
+        stub._host = "app.finansen.no";
+        stub._port = 443;
+        stub._path = "/matssocket";
+        stub._query = "returnUrl=https%3A%2F%2Fexample.com%2Fdone%3Fa%3D1";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        Assert.assertEquals("wss://app.finansen.no/matssocket?returnUrl=https%3A%2F%2Fexample.com%2Fdone%3Fa%3D1",
+                request.getRequestURI().toASCIIString());
+    }
+
+    @Test
     public void userPrincipalAndHttpSession_shouldBeNull() {
         StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
         stub._scheme = "ws";

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeRequest.java
@@ -1,0 +1,146 @@
+package io.mats3.matssocket.quarkus;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link QuarkusHandshakeRequest} - verifies header copying, query string parsing, and URI construction.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
+ */
+public class Test_QuarkusHandshakeRequest {
+
+    @Test
+    public void headers_shouldBeCopiedFromQuarkusHandshake() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._headers = Map.of("Authorization", List.of("Bearer token123"), "Origin", List.of("http://localhost:3000"));
+        stub._scheme = "ws";
+        stub._host = "localhost";
+        stub._port = 8080;
+        stub._path = "/matssocket";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        Assert.assertEquals(List.of("Bearer token123"), request.getHeaders().get("Authorization"));
+        Assert.assertEquals(List.of("http://localhost:3000"), request.getHeaders().get("Origin"));
+    }
+
+    @Test
+    public void queryString_shouldBeParsedIntoParameterMap() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._query = "token=abc&mode=debug&token=def";
+        stub._scheme = "ws";
+        stub._host = "localhost";
+        stub._port = 8080;
+        stub._path = "/matssocket";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        Assert.assertEquals("abc", request.getParameterMap().get("token").get(0));
+        Assert.assertEquals("def", request.getParameterMap().get("token").get(1));
+        Assert.assertEquals("debug", request.getParameterMap().get("mode").get(0));
+        Assert.assertEquals("token=abc&mode=debug&token=def", request.getQueryString());
+    }
+
+    @Test
+    public void requestUri_shouldBeConstructedCorrectly() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._scheme = "wss";
+        stub._host = "app.finansen.no";
+        stub._port = 443;
+        stub._path = "/matssocket";
+        stub._query = "v=1";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        URI uri = request.getRequestURI();
+        Assert.assertEquals("wss", uri.getScheme());
+        Assert.assertEquals("app.finansen.no", uri.getHost());
+        Assert.assertEquals("/matssocket", uri.getPath());
+        Assert.assertEquals("v=1", uri.getQuery());
+    }
+
+    @Test
+    public void requestUri_nonStandardPort_shouldBeIncluded() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._scheme = "ws";
+        stub._host = "localhost";
+        stub._port = 9090;
+        stub._path = "/ws";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        Assert.assertEquals(9090, request.getRequestURI().getPort());
+    }
+
+    @Test
+    public void userPrincipalAndHttpSession_shouldBeNull() {
+        StubQuarkusHandshakeRequest stub = new StubQuarkusHandshakeRequest();
+        stub._scheme = "ws";
+        stub._host = "localhost";
+        stub._port = 80;
+        stub._path = "/ws";
+
+        QuarkusHandshakeRequest request = new QuarkusHandshakeRequest(stub);
+
+        Assert.assertNull(request.getUserPrincipal());
+        Assert.assertNull(request.getHttpSession());
+        Assert.assertFalse(request.isUserInRole("admin"));
+    }
+
+    // ---- Stub for Quarkus HandshakeRequest ----
+
+    private static class StubQuarkusHandshakeRequest implements io.quarkus.websockets.next.HandshakeRequest {
+        Map<String, List<String>> _headers = Map.of();
+        String _scheme = "ws";
+        String _host = "localhost";
+        int _port = 80;
+        String _path = "/";
+        String _query;
+
+        @Override
+        public String header(String name) {
+            List<String> values = _headers.get(name);
+            return values != null && !values.isEmpty() ? values.get(0) : null;
+        }
+
+        @Override
+        public List<String> headers(String name) {
+            return _headers.getOrDefault(name, List.of());
+        }
+
+        @Override
+        public Map<String, List<String>> headers() {
+            return _headers;
+        }
+
+        @Override
+        public String scheme() {
+            return _scheme;
+        }
+
+        @Override
+        public String host() {
+            return _host;
+        }
+
+        @Override
+        public int port() {
+            return _port;
+        }
+
+        @Override
+        public String path() {
+            return _path;
+        }
+
+        @Override
+        public String query() {
+            return _query;
+        }
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeResponse.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusHandshakeResponse.java
@@ -1,0 +1,37 @@
+package io.mats3.matssocket.quarkus;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link QuarkusHandshakeResponse} - verifies header capture and lossy warning behavior.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
+ */
+public class Test_QuarkusHandshakeResponse {
+
+    @Test
+    public void emptyHeaders_shouldNotWarn() {
+        QuarkusHandshakeResponse response = new QuarkusHandshakeResponse();
+        // Should not throw or log warning
+        response.warnIfHeadersWereSet();
+        Assert.assertTrue(response.getHeaders().isEmpty());
+    }
+
+    @Test
+    public void headersSet_shouldBeCaptured() {
+        QuarkusHandshakeResponse response = new QuarkusHandshakeResponse();
+        response.getHeaders().put("Set-Cookie", java.util.List.of("session=abc123"));
+
+        Assert.assertEquals(1, response.getHeaders().size());
+        Assert.assertEquals("session=abc123", response.getHeaders().get("Set-Cookie").get(0));
+    }
+
+    @Test
+    public void headersSet_warnShouldNotThrow() {
+        QuarkusHandshakeResponse response = new QuarkusHandshakeResponse();
+        response.getHeaders().put("Set-Cookie", java.util.List.of("session=abc123"));
+        // Should log warning but not throw
+        response.warnIfHeadersWereSet();
+    }
+}

--- a/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusServerEndpointConfigShim.java
+++ b/matssocket-server-quarkus/src/test/java/io/mats3/matssocket/quarkus/Test_QuarkusServerEndpointConfigShim.java
@@ -1,0 +1,32 @@
+package io.mats3.matssocket.quarkus;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link QuarkusServerEndpointConfigShim}.
+ *
+ * @author Thor Egil Kolltveit 2026-04-12 - thoregil@kolltveit.org
+ */
+public class Test_QuarkusServerEndpointConfigShim {
+
+    @Test
+    public void path_shouldMatchConstructorArg() {
+        QuarkusServerEndpointConfigShim config = new QuarkusServerEndpointConfigShim("/matssocket");
+        Assert.assertEquals("/matssocket", config.getPath());
+    }
+
+    @Test
+    public void subprotocols_shouldContainMatssocket() {
+        QuarkusServerEndpointConfigShim config = new QuarkusServerEndpointConfigShim("/ws");
+        Assert.assertEquals(1, config.getSubprotocols().size());
+        Assert.assertEquals("matssocket", config.getSubprotocols().get(0));
+    }
+
+    @Test
+    public void userProperties_shouldBeMutableAndShared() {
+        QuarkusServerEndpointConfigShim config = new QuarkusServerEndpointConfigShim("/ws");
+        config.getUserProperties().put("key", "value");
+        Assert.assertEquals("value", config.getUserProperties().get("key"));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,7 +18,7 @@ gradleEnterprise {
 
 rootProject.name = 'matssocket'
 
-include 'matssocket-server-api', 'matssocket-server-impl',
+include 'matssocket-server-api', 'matssocket-server-impl', 'matssocket-server-quarkus',
         'matssocket-client-javascript', 'matssocket-client-javascript:client', 'matssocket-client-javascript:tests',
         'matssocket-client-dart',
         'js-client-consumer-canary'


### PR DESCRIPTION
Adds an internal transport session abstraction to decouple MatsSocket core from Jakarta WebSocket for runtime operations (send, close, isOpen, buffer/timeout config). Auth and handshake remain unchanged at the Jakarta API edge.

New module `matssocket-server-quarkus` provides a Quarkus WebSockets Next adapter using thin Jakarta shims only for the existing AuthenticationPlugin API.

No public API changes. Existing Jakarta WebSocket path unchanged — tested with existing test suite.

I contribute this material in accordance with Glimte's signed SCA.